### PR TITLE
first pass turning base mColor to mTint

### DIFF
--- a/samples/NestedViewsSample/src/Content/Header.cpp
+++ b/samples/NestedViewsSample/src/Content/Header.cpp
@@ -17,36 +17,27 @@ Header::~Header(){
 
 void Header::setup() {
 
-	float lineThickness = 6.0f;
-	float lineWidth = 600.0f;
-	float yPos = 100.0f;
-
-	// Create line above text
-	mLine1 = ShapeViewRef(new ShapeView());
-	vec2 startPos = vec2(getWindowWidth()*.5f - lineWidth*0.5f, yPos);
-	vec2 endPos = vec2(getWindowWidth()*.5f + lineWidth*0.5f, yPos);
-	mLine1->createLine(startPos, endPos, lineThickness);
-	mLine1->setColor(ColorA(1.0f, 0.0f, 0.0f, 1.0f));
-
-	// Create line below text
-	mLine2 = ShapeViewRef(new ShapeView());
-	yPos += 100.0f;
-	startPos = vec2(getWindowWidth()*.5f - lineWidth*0.5f, yPos);
-	endPos = vec2(getWindowWidth()*.5f + lineWidth*0.5f, yPos);
-	mLine2->createLine(startPos, endPos, lineThickness);
-	mLine2->setColor(ColorA(1.0f, 0.0f, 0.0f, 1.0f));
-
-	// Add views
-	addChild(mLine1);
-	addChild(mLine2);
+	const ci::ColorA red = ColorA(1.0f, 0.0f, 0.0f, 1.0f);
 
 	// Create title
-	//mTitle = TextViewRef(new TextView());
-	//mTitle->setup(toString("Testing Title"));
-	// Position between lines
-	
-	//addChild(mTitle);
+	mTitle = TextViewRef(new TextView());
+	mTitle->setTextColor(red);
+	mTitle->setFontSize(40.0f, false);
+	mTitle->setText(toString("Testing Title"));
+	mTitle->setPosition(vec2(-mTitle->getWidth()*0.5f, 0.0f)); // Center title within header view horizontally
 
+	// Create underline
+	mUnderline = ShapeViewRef(new ShapeView());
+	float lineThickness = 4.0f;
+	float yPos = mTitle->getPosition().value().y + mTitle->getHeight() + 10.0f;
+	const vec2 startPos = vec2(mTitle->getPosition().value().x, yPos);
+	const vec2 endPos = vec2(startPos.x + mTitle->getWidth(), yPos);
+	mUnderline->createLine(startPos, endPos, lineThickness);
+	mUnderline->setTint(red);
+
+	// Add views
+	addChild(mTitle);
+	addChild(mUnderline);
 }
 
 void Header::update() {

--- a/samples/NestedViewsSample/src/Content/Header.h
+++ b/samples/NestedViewsSample/src/Content/Header.h
@@ -28,7 +28,6 @@ private:
 	virtual void draw() override;
 
 	//! Properties
-//	bluecadet::views::TextViewRef	mTitle; // SM :: Currently not working with latest Cinder - fixing
-	bluecadet::views::ShapeViewRef	mLine1;
-	bluecadet::views::ShapeViewRef	mLine2;
+	bluecadet::views::TextViewRef	mTitle;
+	bluecadet::views::ShapeViewRef	mUnderline;
 };

--- a/samples/NestedViewsSample/src/ContentController.cpp
+++ b/samples/NestedViewsSample/src/ContentController.cpp
@@ -21,6 +21,7 @@ void ContentController::setup() {
 	// Create one header
 	mHeader = HeaderRef(new Header());
 	mHeader->setup();
+	mHeader->setPosition(vec2(getWindowWidth()*0.5f, 40.0f));
 	
 	// Create several detail views
 	for (int i = 0; i < 10; i++) {

--- a/samples/NestedViewsSample/src/NestedViewsSampleApp.cpp
+++ b/samples/NestedViewsSample/src/NestedViewsSampleApp.cpp
@@ -61,7 +61,7 @@ void NestedViewsSampleApp::draw() {
 	gl::clear(Color(0, 0, 0));
 
 	// Draw touches (debugging)
-	mTouchManager->draw();
+	mTouchManager->debugDrawTouches();
 
 	// Draw views & content
 	mContentController->drawScene();

--- a/samples/ShapeViewSample/src/ShapeViewSampleApp.cpp
+++ b/samples/ShapeViewSample/src/ShapeViewSampleApp.cpp
@@ -30,8 +30,8 @@ void ShapeViewSampleApp::setup() {
 		ShapeViewRef circle = ShapeViewRef(new ShapeView());
 		// The ShapeView has the option of being a variety of shapes - this is how we tell it we want it to be a circle. Pass the position and radius.
 		circle->createSolidCircle(vec2(xPos, yPos), radius);
-		// Set the color of this one circle.
-		circle->setColor(ColorA(1.0f, 0.0f, 0.0f, 0.5f));
+		// Set the tint color of this one circle
+		circle->setTint(ColorA(1.0f, 0.0f, 0.0f, 0.5f));
 		// Play around with other properties you can set
 		circle->setAlpha(0.25f);		// You could set a new alpha (without setting the entire color) = animation helper
 		circle->setScale(vec2(1.2));	// Set the scale (hit states perhaps, or animating on/off). 

--- a/samples/TextViewSample/src/TextViewSampleApp.cpp
+++ b/samples/TextViewSample/src/TextViewSampleApp.cpp
@@ -31,9 +31,9 @@ void TextViewSampleApp::setup() {
 	// Since it's a view, we have access to properties like this (animation help)
 	mTitle->setAlpha(0.75f);
 	
-	// The view color affects the overal tint of the view, but not the actual text color
+	// The view tint color affects the overal tint of the view, but not the actual text color
 	// Text + tint color get multiplied (i.e. final color = tintColor * textColor)
-	mTitle->setColor(Color(1.0f, 0.0f, 0.0f));
+	mTitle->setTint(Color(1.0f, 0.0f, 0.0f));
 
 	// This is what actually changes the text color; Gets multiplied with tint color
 	mTitle->setTextColor(Color(1.0f, 1.0f, 1.0f));

--- a/src/BaseView.cpp
+++ b/src/BaseView.cpp
@@ -18,8 +18,8 @@ BaseView::BaseView() :
 	mGlobalTransform(mat4()),
 	mHasInvalidTransforms(true),
 
-	mColor(Color(1.0f, 1.0f, 1.0f)),
-	mColorA(ColorA(1.0f, 1.0f, 1.0f, 1.0f)),
+	mTint(Color(1.0f, 1.0f, 1.0f)),
+	mTintA(ColorA(1.0f, 1.0f, 1.0f, 1.0f)),
 	mAlpha(1.0),
 	mIsHidden(false),
 	mShouldForceRedraw(false),
@@ -44,8 +44,8 @@ void BaseView::reset() {
 	mTransform = mat4();
 	mGlobalTransform = mat4();
 	mHasInvalidTransforms = true;
-	mColor = Color(1.0f, 1.0f, 1.0f);
-	mColorA = ColorA(1.0f, 1.0f, 1.0f, 1.0f);
+	mTint = Color(1.0f, 1.0f, 1.0f);
+	mTintA = ColorA(1.0f, 1.0f, 1.0f, 1.0f);
 	mAlpha = 1.0;
 }
 
@@ -220,7 +220,7 @@ void BaseView::update(const double deltaTime) {
 
 }
 
-void BaseView::drawScene(const ci::ColorA& parentColor) {
+void BaseView::drawScene(const ci::ColorA& parentTint) {
 	if (!mShouldForceRedraw && (mIsHidden || mAlpha <= 0.0f)) {
 		return;
 	}
@@ -234,10 +234,10 @@ void BaseView::drawScene(const ci::ColorA& parentColor) {
 		validateTransforms(false);
 	}
 
-	mColorA.r = mColor.value().r * parentColor.r;
-	mColorA.g = mColor.value().g * parentColor.g;
-	mColorA.b = mColor.value().b * parentColor.b;
-	mColorA.a = mAlpha.value() * parentColor.a;
+	mTintA.r = mTint.value().r * parentTint.r;
+	mTintA.g = mTint.value().g * parentTint.g;
+	mTintA.b = mTint.value().b * parentTint.b;
+	mTintA.a = mAlpha.value() * parentTint.a;
 
 	{
 		gl::ScopedModelMatrix scopedModelMatrix;
@@ -245,11 +245,11 @@ void BaseView::drawScene(const ci::ColorA& parentColor) {
 		//gl::ScopedBlendAlpha scopedBlendAlpha; // bb: no real need for this at this point since we're not changing blend modes a lot
 
 		gl::multModelMatrix(mTransform);
-		gl::color(mColorA);
+		gl::color(mTintA);
 
 		willDraw();
 		draw();
-		drawChildren(mColorA);
+		drawChildren(mTintA);
 		didDraw();
 	}
 
@@ -265,9 +265,9 @@ void BaseView::draw() {
 	// override this method
 }
 
-void BaseView::drawChildren(const ci::ColorA& parentColor) {
+void BaseView::drawChildren(const ci::ColorA& parentTint) {
 	for (auto child : mChildren) {
-		child->drawScene(parentColor);
+		child->drawScene(parentTint);
 	}
 }
 
@@ -317,7 +317,7 @@ void BaseView::resetAnimations() {
 	mPosition.stop();
 	mRotation.stop();
 	mScale.stop();
-	mColor.stop();
+	mTint.stop();
 	mAlpha.stop();
 }
 

--- a/src/BaseView.h
+++ b/src/BaseView.h
@@ -41,7 +41,7 @@ public:
 	virtual void			updateScene(double deltaTime);
 
 	//! Applies tint color, alpha and matrices and then draws itself and all children. Validates transforms internally.
-	virtual void			drawScene(const ci::ColorA& parentColor = ci::ColorA(1.0f, 1.0f, 1.0, 1.0f)) final;
+	virtual void			drawScene(const ci::ColorA& parentTint = ci::ColorA(1.0f, 1.0f, 1.0, 1.0f)) final;
 
 	//! Used for all internal animations
 	ci::TimelineRef			getTimeline();
@@ -102,11 +102,11 @@ public:
 	virtual const ci::mat4&				getGlobalTransform() { if (mHasInvalidTransforms) { validateTransforms(); }; return mGlobalTransform; }
 
 	//! Applied before each draw together with mAlpha; Defaults to white
-	virtual ci::Anim<ci::Color>&		getColor() { return mColor; }
-	virtual void						setColor(const ci::Color color) { mColor = color; }
-	virtual void						setColor(const ci::ColorA color) { mColor = color; mAlpha = color.a; } //! Sets mColor and mAlpha properties
+	virtual ci::Anim<ci::Color>&		getTint() { return mTint; }
+	virtual void						setTint(const ci::Color tint) { mTint = tint; }
+	virtual void						setTint(const ci::ColorA tint) { mTint = tint; mAlpha = tint.a; } //! Sets mTint and mAlpha properties
 
-	//! Applied before each draw together with mColor; Gets multiplied with parent alpha; Defaults to 1.0f
+	//! Applied before each draw together with mTint; Gets multiplied with parent alpha; Defaults to 1.0f
 	virtual ci::Anim<float>&			getAlpha() { return mAlpha; }
 	virtual void						setAlpha(const float alpha) { mAlpha = alpha; }
 
@@ -147,13 +147,13 @@ protected:
 
 	virtual void willDraw();		//! Called by drawScene before draw()
 	virtual void draw();			//! Called by drawScene and allows for drawing content for this node
-	virtual void drawChildren(const ci::ColorA& parentColor);	//! Called by drawScene() after draw() and before didDraw()
+	virtual void drawChildren(const ci::ColorA& parentTint);	//! Called by drawScene() after draw() and before didDraw()
 	virtual void didDraw();			//! Called by drawScene after draw()
 
 	virtual void didMoveToView(BaseView* parent);		//! Called when moved to a parent
 	virtual void willMoveFromView(BaseView* parent);	//! Called when removed from a parent
 
-	const ci::ColorA& getColorA() const { return mColorA; }
+	const ci::ColorA& getTintA() const { return mTintA; }
 
 private:
 
@@ -161,7 +161,7 @@ private:
 	BaseViewList mChildren;
 
 	ci::TimelineRef mTimeline;
-	ci::Anim<ci::Color> mColor;
+	ci::Anim<ci::Color> mTint;
 	ci::Anim<float> mAlpha;
 	bool mIsHidden;
 	bool mShouldForceRedraw;
@@ -169,7 +169,7 @@ private:
 	ci::Anim<ci::vec2> mPosition;
 	ci::Anim<ci::vec2> mScale;
 	ci::Anim<ci::quat> mRotation;
-	ci::ColorA mColorA; //! For internal use only; Merges mAlpha and mColor for faster draw
+	ci::ColorA mTintA; //! For internal use only; Merges mAlpha and mColor for faster draw
 
 	ci::mat4 mTransform;
 	ci::mat4 mGlobalTransform;

--- a/src/debug/RectButton.cpp
+++ b/src/debug/RectButton.cpp
@@ -28,7 +28,7 @@ void RectButton::setup(const vec2& size, const ci::ColorA& touchUpColor, const c
 }
 
 void RectButton::update(double deltaTime) {
-	setColor((getNumTouches() > 0) ? mTouchDownColor : mTouchUpColor);
+	setTint((getNumTouches() > 0) ? mTouchDownColor : mTouchUpColor);
 }
 
 void RectButton::draw() {

--- a/src/debug/RectView.cpp
+++ b/src/debug/RectView.cpp
@@ -12,8 +12,8 @@ namespace debug {
 // Lifecycle
 // 
 
-RectView::RectView(const vec2& size, const ci::ColorA& color) : views::BaseView() {
-	setColor(color);
+RectView::RectView(const vec2& size, const ci::ColorA& tint) : views::BaseView() {
+	setTint(tint);
 	Rectf rect = Rectf(0.0f, 0.0f, size.x, size.y);
 	auto shaderDef = gl::ShaderDef().color();
 	gl::GlslProgRef shader = gl::getStockShader(shaderDef);

--- a/src/debug/RectView.h
+++ b/src/debug/RectView.h
@@ -23,7 +23,7 @@ class RectView : public BaseView {
 
 public:
 
-	RectView(const ci::vec2& size, const ci::ColorA& color = ci::ColorA(1, 0, 0, 0.5));
+	RectView(const ci::vec2& size, const ci::ColorA& tint = ci::ColorA(1, 0, 0, 0.5));
 	virtual ~RectView();
 
 protected:


### PR DESCRIPTION
- baseView mColor to mTint
- baseView setColor/getColor to setTint/getTint
- baseView parentColor to parentTint
- updated samples
- Overall I think it makes sense when using tint for a view that has items inside that have their own colors, but otherwise not as clear. Examples:

```
mText->setTint()
mText->setTextColor()
mText->setBackgroundColor()

mCircle->setTint() // never set a color anywhere, so the idea of applying tint is a little weird
```

updates with #10 might help, where we may introduce a background color?

@benjaminbojko / team  let me know what you think
