### PR TITLE
Screen layout now doesn't manipulate root view directly anymore

### DIFF
--- a/src/BaseView.h
+++ b/src/BaseView.h
@@ -170,7 +170,7 @@ public:
 	const ci::vec2						convertLocalToGlobal(const ci::vec2& local) { ci::vec4 global = getGlobalTransform() * ci::vec4(local, 0, 1); return ci::vec2(global.x, global.y); }
 	
 	//! Converts a position from the root view's global space to the current view's local space.
-	const ci::vec2						convertGlobalToLocal(const ci::vec2& global) { ci::vec4 local = glm::inverse(getGlobalTransform()) * ci::vec4(global, 0, 1);	return ci::vec2(local.x, local.y); };
+	const ci::vec2						convertGlobalToLocal(const ci::vec2& global) { ci::vec4 local = glm::inverse(getGlobalTransform()) * ci::vec4(global, 0, 1); return ci::vec2(local); };
 
 
 

--- a/src/ScreenLayout.h
+++ b/src/ScreenLayout.h
@@ -30,7 +30,7 @@ public:
 
 
 	//! Must be called before calling draw. Adds a key-up event listener.
-	void			setup(views::BaseViewRef rootView, const ci::ivec2& dislaySize = ci::ivec2(1920, 1080), const int numRows = 1, const int numColumns = 1);
+	void			setup(const ci::ivec2& dislaySize = ci::ivec2(1920, 1080), const int numRows = 1, const int numColumns = 1);
 
 
 
@@ -49,7 +49,7 @@ public:
 
 	//! The size of a single display in the display matrix
 	ci::ivec2		getDisplaySize() const { return mDisplaySize; }
-	void			 setDisplaySize(const ci::ivec2 value) { mDisplaySize = value; }
+	void			setDisplaySize(const ci::ivec2 value) { mDisplaySize = value; }
 
 	//! The number of rows of displays in the display matrix.
 	int				getNumRows() const { return mNumRows; };
@@ -110,15 +110,16 @@ public:
 	void				setBorderColor(const ci::ColorA& color) { mBorderColor = color; };
 	
 	//! The border size used when drawing the display bounds. Defaults to 4.
-	float			getBordeSize() const { return mBorderSize; }
-	void			setBorderSize(const float value) { mBorderSize = value; }
+	float				getBordeSize() const { return mBorderSize; }
+	void				setBorderSize(const float value) { mBorderSize = value; }
 
+	const ci::mat4&		getTransform() const { return mPlaceholderView->getTransform(); };
 
 protected:
-	float			getScaleToFitBounds(const ci::Rectf &bounds, const ci::vec2 &maxSize, const float padding = 0.0f) const;
+	float				getScaleToFitBounds(const ci::Rectf &bounds, const ci::vec2 &maxSize, const float padding = 0.0f) const;
 
-	void			updateLayout();
-	void			handleKeyDown(ci::app::KeyEvent event);
+	void				updateLayout();
+	void				handleKeyDown(ci::app::KeyEvent event);
 
 
 	//! Layout
@@ -134,9 +135,7 @@ protected:
 private:
 	//! Used to draw bounds of each display
 	std::vector<ci::Rectf>	mDisplayBounds;
-
-	// From BaseApp
-	views::BaseViewRef		mRootView;
+	views::BaseViewRef		mPlaceholderView;
 };
 
 }


### PR DESCRIPTION
Here's a first attempt at fixing #47. I'm not 100% excited about how I solved this yet, but it fixes the issue of touches being inconsistent when `ScreenLayout` zooms/pans the app.
- Before this fix, `ScreenLayout` would directly translate and scale the root view in `BaseApp`.
- With this fix, `ScreenLayout` has an internal "shadow" view that is translated and scaled

`BaseApp` applies the shadow view's transformation matrix to:
- All touches in order to transform the touches from window coordinate space into app space in `update()`
- The model matrix before drawing `mRootView` to transform the app to the translation and scale defined in `ScreenLayout`

It seems to work pretty well, but it does create new dependencies. On the flip side, it eliminates the dependency of `ScreenLayout` knowing about `mRootView`, which I never really was a fan of.

@Swiley any thoughts?

CC @shiwl 
