### PR TITLE
BaseApp now launches in foreground on Windows

### DIFF
--- a/src/BaseApp.cpp
+++ b/src/BaseApp.cpp
@@ -47,7 +47,7 @@ void BaseApp::setup() {
 		hideCursor();
 	}
 
-#if defined( CINDER_MSW )
+#if defined(CINDER_MSW)
 	// Move window to foreground so that console output doesn't obstruct it
 	HWND nativeWindow = (HWND)getWindow()->getNative();
 	::SetForegroundWindow(nativeWindow);


### PR DESCRIPTION
This has annoyed me for a while, so here's a fix.

**Before**: Enabling a console window would always launch the console window in the foreground.
**After**: App window now launches in the foreground with console window behind it.

Any objections to making this the default?
