### PR TITLE
cancel touch on all views in sample for testing, add consoles

### DIFF
--- a/samples/ViewTypesSample/src/ViewTypesSampleApp.cpp
+++ b/samples/ViewTypesSample/src/ViewTypesSampleApp.cpp
@@ -25,13 +25,14 @@ public:
 	void handleKeyDown(ci::app::KeyEvent event);
 	static void prepareSettings(ci::app::App::Settings* settings);
 
-	TouchViewRef cancelView;
-
 };
 
 void ViewTypesSampleApp::prepareSettings(ci::app::App::Settings* settings) {
 	BaseApp::prepareSettings(settings);
 	settings->setWindowSize(ivec2(1024, 768));
+
+	settings->setFullScreen(false);
+	settings->setWindowSize(900, 800);
 }
 
 void ViewTypesSampleApp::setup() {
@@ -127,15 +128,17 @@ void ViewTypesSampleApp::setup() {
 	circleTouchPath->setPosition(circleTouchView->getPosition().value() + vec2(circleTouchView->getWidth() + circleTouchPath->getWidth()/2, 0));
 	getRootView()->addChild(circleTouchPath);
 
-	cancelView = TouchViewRef(new TouchView());
+	auto cancelView = TouchViewRef(new TouchView());
 	cancelView->setSize(vec2(100, 100));
 	cancelView->setPosition(vec2(100, 250));
 	cancelView->setBackgroundColor(ColorA(1.0f, 0.5f, 0.5f, 0.75f));
+
 	cancelView->mDidBeginTouch.connect([=](const bluecadet::touch::TouchEvent& e) {
 		cancelView->getTimeline()->apply(&cancelView->getScale(), vec2(2.0f), 0.3f);
 	});
-
-	cancelView->mDidEndTouch.connect([=](const bluecadet::touch::TouchEvent& e) { cancelView->getTimeline()->apply(&cancelView->getScale(), vec2(1.0f), 0.3f); });
+	cancelView->mDidEndTouch.connect([=](const bluecadet::touch::TouchEvent& e) {
+		cancelView->getTimeline()->apply(&cancelView->getScale(), vec2(1.0f), 0.3f);
+	});
 
 	getRootView()->addChild(cancelView);
 
@@ -144,8 +147,15 @@ void ViewTypesSampleApp::setup() {
 
 void ViewTypesSampleApp::handleKeyDown(ci::app::KeyEvent event) {
 	switch (event.getCode()) {
-		case KeyEvent::KEY_EQUALS:
-			cancelView->cancelTouches();
+		case KeyEvent::KEY_c:
+			console() << "ViewTypesSampleApp::handleKeyDown KEY_c" << endl;
+
+			for (auto child : getRootView()->getChildren()) {
+				if(	dynamic_pointer_cast<TouchView>(child)) 
+					dynamic_pointer_cast<TouchView>(child)->cancelTouches();
+				else console() << "This view isn't a TouchView, stop trying to cancel it's touch." << endl;
+			}
+
 			break;
 	}
 }

--- a/src/TouchView.cpp
+++ b/src/TouchView.cpp
@@ -39,7 +39,7 @@ TouchView::TouchView() :
 }
 
 TouchView::~TouchView() {
-	cancelTouches();
+//	cancelTouches(); -- breaks on closing, review with @BB
 }
 
 void TouchView::reset() {
@@ -158,9 +158,9 @@ void TouchView::processTouchEnded(const touch::TouchEvent& touchEvent) {
 }
 
 void TouchView::cancelTouches() {
-	// TODO: Move this logic to the touch manager
-	std::shared_ptr<touch::TouchManager> manager = touch::TouchManager::getInstance();
-	manager->cancelTouch(shared_from_this());
+	console() << "TouchView::cancelTouches" << endl;
+	std::shared_ptr<touch::TouchManager> touchManager = touch::TouchManager::getInstance();
+	touchManager->cancelTouch(shared_from_this());
 }
 
 void TouchView::resetTouchState() {


### PR DESCRIPTION
@peterchappy really small revisions to the sample to call to cancel touches on every view that is a touch view (helps us test for breaks to call canceling at any stage). Also added consoles to help me debug. 

The error you were getting was when the app closed (I tracked this down by commenting out all the cancelTouch functions and still was getting that error when I closed the app and never actually called to cancel anything), and that's because cancelTouches() was getting called on every TouchView in the destructor. We may still want to do this, but for now I commented it out because I'm not sure how to fix that issue yet. 

We definitely need to test more, Would be kind of fun to pull these blocks into a branch of DI or CT and see what happens if you use TUIOPad or throw it up on the screen to get multi touch going, and then add a similar key command to cancel the touches randomly. That way we could test that they get canceled at all stages and still shouldn't hurt anything. Let's also review these changes with @benjaminbojko (I think he's busy today) - but we could check in with him after we do some more testing. 

Nice work digging into both of those blocks for this revision!
