### PR TITLE
remove const from handleEvent functions

### DIFF
--- a/src/views/BaseView.h
+++ b/src/views/BaseView.h
@@ -111,7 +111,7 @@ public:
 	virtual ci::CueRef		dispatchAfter(std::function<void()> fn, float delay = 0.0f);
 
 	//! Override to handle dispatched events from children.
-	virtual void			handleEvent(const ViewEvent & event) {}
+	virtual void			handleEvent(ViewEvent & event) {}
 
 
 	//==================================================

--- a/src/views/FboView.cpp
+++ b/src/views/FboView.cpp
@@ -76,7 +76,7 @@ inline void FboView::validateContent(){
 
 }
 
-void FboView::handleEvent(const ViewEvent& event) {
+void FboView::handleEvent(ViewEvent& event) {
 	if (event.type == ViewEvent::Type::CONTENT_INVALIDATED) {
 		invalidate(false, true);
 	}

--- a/src/views/FboView.h
+++ b/src/views/FboView.h
@@ -35,7 +35,7 @@ public:
 	void			setForceRedraw(const bool value) { mForceRedraw = value; }
 
 	//! Listens for contentUpdated events. This fires with it's own or a child view's size, scale, rotation, transform or position are updated.
-	void			handleEvent(const ViewEvent& event) override;
+	void			handleEvent(ViewEvent& event) override;
 
 protected:
 


### PR DESCRIPTION
There is a discussion somewhere on Github (candy to whoever can find it) - where we wanted to be able to call `event.stopPropagation();` throughout the app.

From what I recall, there was no strong reason to have it pass a const. Let me know if you think of any reason we shouldn't do this. 