### PR TITLE
Initialize TouchManager::mLatestTouchTime to 0

### DIFF
--- a/src/bluecadet/touch/TouchManager.cpp
+++ b/src/bluecadet/touch/TouchManager.cpp
@@ -17,7 +17,8 @@ using namespace bluecadet::views;
 
 TouchManager::TouchManager() :
 	mDiscardMissedTouches(true),
-	mMultiTouchEnabled(true) {
+	mMultiTouchEnabled(true),
+	mLatestTouchTime(0) {
 }
 
 TouchManager::~TouchManager() {

--- a/src/bluecadet/touch/TouchManager.h
+++ b/src/bluecadet/touch/TouchManager.h
@@ -125,7 +125,7 @@ protected:
 	std::recursive_mutex						mQueueMutex;
 	std::deque<Touch>							mTouchQueue;		 // Collects all touch events until they're processed on the main thread
 
-	bool										mDiscardMissedTouches = true;
+	bool										mDiscardMissedTouches;
 	bool										mMultiTouchEnabled;
 	float                                       mLatestTouchTime;
 


### PR DESCRIPTION
TouchManager::mLatestTouchTime was never initialized, which means on good ol' MSVC it was returning as `-nan` instead of `0`.

Also remove intialization of `mDiscardMissedTouches` from the header since it's set in the constructor