### PR TITLE
Use getSize() instead of mSize directly in BaseView

### DIFF
--- a/src/bluecadet/views/BaseView.h
+++ b/src/bluecadet/views/BaseView.h
@@ -164,13 +164,13 @@ public:
 	virtual void						setPosition(const ci::vec3& position) { mPosition = ci::vec2(position.x, position.y); invalidate(); }
 
 	//! Shorthand for combining position and size to center the view at `center`
-	virtual void						setCenter(const ci::vec2 center) { setPosition(center - 0.5f * mSize); }
+	virtual void						setCenter(const ci::vec2 center) { setPosition(center - 0.5f * getSize()); }
 
 	//! Shorthand for getting the center based on the current position and size
-	virtual ci::vec2					getCenter() { return getPosition().value() + 0.5f * mSize; }
+	virtual ci::vec2					getCenter() { return getPosition().value() + 0.5f * getSize(); }
 
 	//! Shorthand for getting the bounds based on the current position and size
-	virtual ci::Rectf					getBounds() { return ci::Rectf(getPosition(), getPosition().value() + mSize); }
+	virtual ci::Rectf					getBounds() { return ci::Rectf(getPosition(), getPosition().value() + getSize()); }
 
 	//! Local scale relative to parent view
 	virtual ci::Anim<ci::vec2>&			getScale() { return mScale; }


### PR DESCRIPTION
I KNEW when I added `getBounds()` that not switching `mSize` to `getSize()` was going to come back and bite me at some point... 😏 

The `setCenter()`, `getCenter()`, and `getSize()` methods (and therefore `getBounds()`) methods would all return incorrect values for `TextView`, as this class overrides `getSize()` to account for the max size vs text size, and doesn't use `mSize`.

Switching these setters & getters to using the `getSize()` getter now returns correct values for `TextView`.