### PR TITLE
Feature/premult rendering

### DIFF
--- a/samples/ViewTypesSample/src/ViewTypesSampleApp.cpp
+++ b/samples/ViewTypesSample/src/ViewTypesSampleApp.cpp
@@ -278,7 +278,6 @@ void ViewTypesSampleApp::addViewSample(BaseViewRef view, std::string label) {
 	container->setSize(cellSize);
 	container->setPosition(cellPos);
 	container->setBackgroundColor(Color::black());
-	//container->setBackgroundColor(Color(1, 1, 0));
 	getRootView()->addChild(container);
 
 	vec2 viewOffset = view->getPosition();

--- a/samples/ViewTypesSample/src/ViewTypesSampleApp.cpp
+++ b/samples/ViewTypesSample/src/ViewTypesSampleApp.cpp
@@ -51,6 +51,8 @@ void ViewTypesSampleApp::prepareSettings(ci::app::App::Settings* settings) {
 void ViewTypesSampleApp::setup() {
 	BaseApp::setup();
 
+	getRootView()->setBackgroundColor(Color::gray(0.5f));
+
 	//==================================================
 	// Most basic view
 	// 
@@ -176,8 +178,6 @@ void ViewTypesSampleApp::setup() {
 		addViewSample(dragView, "TouchView with y drag");
 	}
 
-	getRootView()->setBackgroundColor(Color::gray(0.5f));
-
 	//==================================================
 	// FBO
 	// 
@@ -278,6 +278,7 @@ void ViewTypesSampleApp::addViewSample(BaseViewRef view, std::string label) {
 	container->setSize(cellSize);
 	container->setPosition(cellPos);
 	container->setBackgroundColor(Color::black());
+	//container->setBackgroundColor(Color(1, 1, 0));
 	getRootView()->addChild(container);
 
 	vec2 viewOffset = view->getPosition();

--- a/src/bluecadet/core/SettingsManager.cpp
+++ b/src/bluecadet/core/SettingsManager.cpp
@@ -92,7 +92,7 @@ void SettingsManager::setup(ci::app::App::Settings * appSettings, ci::fs::path j
 
 void SettingsManager::parseJson(ci::JsonTree & json) {
 	// General
-	setFieldFromJsonIfExists(&mConsole, "settings.general.consoleWindowEnabled");
+	//setFieldFromJsonIfExists(&mConsole, "settings.general.consoleWindowEnabled");
 	setFieldFromJsonIfExists(&mConsole, "settings.general.console");
 	setFieldFromJsonIfExists(&mAppVersion, "settings.general.version");
 
@@ -107,7 +107,7 @@ void SettingsManager::parseJson(ci::JsonTree & json) {
 	// Window
 	setFieldFromJsonIfExists(&mFps, "settings.window.fps");
 	setFieldFromJsonIfExists(&mFps, "settings.window.FPS");
-	setFieldFromJsonIfExists(&mVerticalSync, "settings.window.verticalSync");
+	//setFieldFromJsonIfExists(&mVerticalSync, "settings.window.verticalSync");
 	setFieldFromJsonIfExists(&mVerticalSync, "settings.window.vsync");
 	setFieldFromJsonIfExists(&mFullscreen, "settings.window.fullscreen");
 	setFieldFromJsonIfExists(&mBorderless, "settings.window.borderless");
@@ -126,13 +126,13 @@ void SettingsManager::parseJson(ci::JsonTree & json) {
 	setFieldFromJsonIfExists(&mNativeTouchEnabled, "settings.touch.native");
 
 	// Debug
-	setFieldFromJsonIfExists(&mDebugEnabled, "settings.debug.debugMode");
+	//setFieldFromJsonIfExists(&mDebugEnabled, "settings.debug.debugMode");
 	setFieldFromJsonIfExists(&mDebugEnabled, "settings.debug.debugEnabled");
 	setFieldFromJsonIfExists(&mShowStats, "settings.debug.showStats");
 	setFieldFromJsonIfExists(&mShowMinimap, "settings.debug.showMinimap");
 	setFieldFromJsonIfExists(&mShowTouches, "settings.debug.showTouches");
 	setFieldFromJsonIfExists(&mShowScreenLayout, "settings.debug.showScreenLayout");
-	setFieldFromJsonIfExists(&mShowCursor, "settings.debug.showMouse");
+	//setFieldFromJsonIfExists(&mShowCursor, "settings.debug.showMouse");
 	setFieldFromJsonIfExists(&mShowCursor, "settings.debug.showCursor");
 	setFieldFromJsonIfExists(&mMinimizeParams, "settings.debug.minimizeParams");
 	setFieldFromJsonIfExists(&mCollapseParams, "settings.debug.collapseParams");

--- a/src/bluecadet/touch/TouchManager.cpp
+++ b/src/bluecadet/touch/TouchManager.cpp
@@ -335,7 +335,7 @@ void TouchManager::debugDrawTouch(const Touch & touch, const bool isVirtual) {
 		gl::scale(vec2(circleScale));
 
 		fboNormal->bindFramebuffer();
-		gl::clear(ColorA(1 ,1, 1, 0));
+		gl::clear(ColorA(1, 1, 1, 0));
 		
 		{
 			gl::ScopedColor scopedColor(ColorA(0, 0, 0, 0.5f));
@@ -349,7 +349,7 @@ void TouchManager::debugDrawTouch(const Touch & touch, const bool isVirtual) {
 		fboNormal->unbindFramebuffer();
 
 		fboVirtual->bindFramebuffer();
-		gl::clear(ColorA(1 ,1, 1, 0));
+		gl::clear(ColorA(1, 1, 1, 0));
 		
 		{
 			gl::ScopedColor scopedColor(ColorA(0, 0, 0, 0.5f));

--- a/src/bluecadet/views/ArcView.cpp
+++ b/src/bluecadet/views/ArcView.cpp
@@ -60,13 +60,6 @@ void ArcView::draw() {
 	batch->draw();
 }
 
-void ArcView::debugDrawOutline() {
-	gl::ScopedModelMatrix scopedModelMatrix;
-	gl::ScopedViewMatrix scopedViewMatrix;
-	gl::translate(-getSize() * 0.5f);
-	BaseView::debugDrawOutline();
-}
-
 ci::gl::BatchRef ArcView::getSharedBatch() {
 	static ci::gl::BatchRef batch = nullptr;
 	if (!batch) {

--- a/src/bluecadet/views/ArcView.h
+++ b/src/bluecadet/views/ArcView.h
@@ -42,10 +42,16 @@ public:
 	//! Cancels ArcView animations in addition to BaseView animations.
 	void cancelAnimations() override;
 
+	//! Arc bounds extend -outerRadius to +outerRadius both for x and y
+	ci::Rectf getBounds(const bool scaled) override {
+		ci::Rectf bounds = BaseView::getBounds(scaled);
+		bounds.offset(-0.5f * bounds.getSize());
+		return bounds;
+	}
+
 protected:
 	void update(const double deltaTime) override;
 	void draw() override;
-	void debugDrawOutline() override;
 
 	static ci::gl::BatchRef		getSharedBatch();
 	static ci::gl::GlslProgRef	getSharedProg();

--- a/src/bluecadet/views/BaseView.cpp
+++ b/src/bluecadet/views/BaseView.cpp
@@ -52,7 +52,8 @@ BaseView::BaseView() :
 	mParent(nullptr),
 	
 	mViewId(sNumInstances++),
-	mViewIdStr(to_string(mViewId))
+	mViewIdStr(to_string(mViewId)),
+	mName(mViewIdStr)
 	{
 }
 
@@ -269,17 +270,17 @@ void BaseView::updateScene(const double deltaTime) {
 	}
 }
 
-void BaseView::drawScene(const ColorA& parentTint) {
+void BaseView::drawScene(const ColorA& parentDrawColor) {
 	const bool shouldDraw = mShouldForceInvisibleDraw || (!mIsHidden && mAlpha > 0.0f);
 
 	if (shouldDraw || (sDebugDrawBounds && sDebugDrawInvisibleBounds)) {
 		validateTransforms();
 		validateContent();
 
-		mDrawColor.r = mTint.value().r * parentTint.r;
-		mDrawColor.g = mTint.value().g * parentTint.g;
-		mDrawColor.b = mTint.value().b * parentTint.b;
-		mDrawColor.a = mAlpha.value() * parentTint.a;
+		mDrawColor.r = mTint.value().r * parentDrawColor.r;
+		mDrawColor.g = mTint.value().g * parentDrawColor.g;
+		mDrawColor.b = mTint.value().b * parentDrawColor.b;
+		mDrawColor.a = mAlpha.value() * parentDrawColor.a;
 
 		gl::ScopedModelMatrix scopedModelMatrix;
 		gl::ScopedViewMatrix scopedViewMatrix;
@@ -343,10 +344,14 @@ void BaseView::draw() {
 }
 
 inline void BaseView::debugDrawOutline() {
+	static const Font labelFont = Font("Arial", 20);
+	static const vec2 labelPos = vec2(0, 0);
 	const float hue = (float)mViewId / (float)sNumInstances;
-	const auto color = ColorAf(ci::hsvToRgb(vec3(hue, 1.0f, 1.0f)), 0.66f);
-	gl::color(color);
+	const ColorA color(ci::hsvToRgb(vec3(hue, 1.0f, 1.0f)), 0.9f);
+	gl::ScopedColor scopedColor(color);
+	gl::ScopedLineWidth lineWidth(1.0f);
 	gl::drawStrokedRect(Rectf(vec2(0), getSize()));
+	gl::drawString(mName, labelPos, color, labelFont);
 }
 
 //==================================================

--- a/src/bluecadet/views/BaseView.cpp
+++ b/src/bluecadet/views/BaseView.cpp
@@ -346,11 +346,14 @@ void BaseView::draw() {
 inline void BaseView::debugDrawOutline() {
 	static const Font labelFont = Font("Arial", 20);
 	static const vec2 labelPos = vec2(0, 0);
+	static const float crosshairRadius = 5.0f;
 	const float hue = (float)mViewId / (float)sNumInstances;
 	const ColorA color(ci::hsvToRgb(vec3(hue, 1.0f, 1.0f)), 0.9f);
 	gl::ScopedColor scopedColor(color);
 	gl::ScopedLineWidth lineWidth(1.0f);
-	gl::drawStrokedRect(Rectf(vec2(0), getSize()));
+	gl::drawStrokedRect(getBounds(false).getOffset(-getPosition()));
+	gl::drawLine(vec2(-crosshairRadius, -crosshairRadius), vec2(crosshairRadius, crosshairRadius));
+	gl::drawLine(vec2(-crosshairRadius, crosshairRadius), vec2(crosshairRadius, -crosshairRadius));
 	gl::drawString(mName, labelPos, color, labelFont);
 }
 

--- a/src/bluecadet/views/BaseView.h
+++ b/src/bluecadet/views/BaseView.h
@@ -162,7 +162,8 @@ public:
 	virtual const size_t				getNumChildren() const { return mChildren.size(); }
 
 	//! Local position relative to parent view
-	virtual ci::Anim<ci::vec2>&			getPosition() { return mPosition; }
+	virtual ci::Anim<ci::vec2> &		getPosition() { return mPosition; }
+	virtual const ci::vec2 &			getPositionConst() const { return mPosition.value(); }
 	virtual void						setPosition(const ci::vec2& position) { mPosition = position; invalidate(); }
 	virtual void						setPosition(const ci::vec3& position) { mPosition = ci::vec2(position.x, position.y); invalidate(); }
 
@@ -173,13 +174,15 @@ public:
 	virtual ci::vec2					getCenter() { return getPosition().value() + 0.5f * getSize(); }
 
 	//! Local scale relative to parent view
-	virtual ci::Anim<ci::vec2>&			getScale() { return mScale; }
+	virtual ci::Anim<ci::vec2> &		getScale() { return mScale; }
+	virtual const ci::vec2 &			getScaleConst() const { return mScale.value(); }
 	virtual void						setScale(const float& scale) { mScale = ci::vec2(scale, scale);  invalidate(); }
 	virtual void						setScale(const ci::vec2& scale) { mScale = scale;  invalidate(); }
 	virtual void						setScale(const ci::vec3& scale) { mScale = ci::vec2(scale.x, scale.y);  invalidate(); }
 
 	//! Local rotation relative to parent view. Changing this value invalidates transforms.
-	virtual ci::Anim<ci::quat>&			getRotation() { return mRotation; }
+	virtual ci::Anim<ci::quat> &		getRotation() { return mRotation; }
+	virtual const ci::quat &			getRotationConst() { return mRotation.value(); }
 	virtual float						getRotationZ() const { return glm::roll(mRotation.value()); }
 	virtual void						setRotation(const float radians) { mRotation = glm::angleAxis(radians, ci::vec3(0, 0, 1)); invalidate(); }
 	virtual void						setRotation(const ci::quat& rotation) { mRotation = rotation; invalidate(); }
@@ -206,6 +209,9 @@ public:
 	virtual float						getHeight() { return getSize().y; }
 	virtual void						setHeight(const float height) { ci::vec2 s = getSize(); setSize(ci::vec2(s.x, height)); }
 
+	//! Combined size and position in parent coordinate space. Set scaled to true to multiply size by scale. Does not include rotation.
+	virtual ci::Rectf					getBounds(const bool scaled = false) { return ci::Rectf(getPositionConst(), getPositionConst() + (scaled ? getScaleConst() * getSize() : getSize())); }
+
 	//! The fill color used when drawing the bounding rect when a size greater than 0, 0 is given.
 	virtual ci::Anim<ci::ColorA>&		getBackgroundColor() { return mBackgroundColor; }
 	virtual void						setBackgroundColor(const ci::Color color) { mBackgroundColor = ci::ColorA(color, 1.0f); invalidate(false, true); } //! Sets background color with 100% alpha
@@ -221,7 +227,7 @@ public:
 	virtual void						setAlpha(const float alpha) { mAlpha = alpha; }
 
 	//! Returns a constant reference of getAlpha(). Allows for const access.
-	virtual const ci::Anim<float>&		getAlphaConst() const { return mAlpha; }
+	virtual float						getAlphaConst() const { return mAlpha; }
 	
 	//! Defaults to inherit (doesn't change the blend mode).
 	BlendMode							getBlendMode() const { return mBlendMode; }

--- a/src/bluecadet/views/BaseView.h
+++ b/src/bluecadet/views/BaseView.h
@@ -94,7 +94,7 @@ public:
 	virtual void			updateScene(double deltaTime);
 
 	//! Applies tint color, alpha and matrices and then draws itself and all children. Validates transforms internally.
-	virtual void			drawScene(const ci::ColorA& parentTint = ci::ColorA(1.0f, 1.0f, 1.0, 1.0f)) final;
+	virtual void			drawScene(const ci::ColorA& parentDrawColor = ci::ColorA(1.0f, 1.0f, 1.0, 1.0f)) final;
 
 	//! Used for all internal animations
 	ci::TimelineRef			getTimeline();
@@ -225,7 +225,7 @@ public:
 	
 	//! Defaults to inherit (doesn't change the blend mode).
 	BlendMode							getBlendMode() const { return mBlendMode; }
-	void								setBlendMode(const BlendMode value) { mBlendMode = value; }
+	virtual void						setBlendMode(const BlendMode value) { mBlendMode = value; }
 
 	//! Disables drawing; Update calls are not affected; Defaults to false
 	virtual bool						isHidden() const { return mIsHidden; }
@@ -246,6 +246,10 @@ public:
 	//! Unique ID per view.
 	const size_t						getViewId() const { return mViewId; }
 	const std::string &					getViewIdStr() const { return mViewIdStr; }
+
+	//! Custom name that can be assigned to view and used for debugging; Defaults to view id string.
+	const std::string &					getName() const { return mName; }
+	void								setName(const std::string & name) { mName = name; }
 
 
 	//==================================================
@@ -312,11 +316,11 @@ protected:
 	inline virtual void	willDraw() {}							//! Called by drawScene before draw()
 	virtual void		draw();									//! Called by drawScene and allows for drawing content for this node. By default draws a rectangle with the current size and background color (only if x/y /bg-alpha > 0)
 	virtual void		debugDrawOutline();						//! Called in DEBUG if sDebugDrawBounds is set to true.
-	inline virtual void	drawChildren(const ci::ColorA& parentTint); //! Called by drawScene() after draw() and before didDraw(). Implemented at bottom of class.
+	inline virtual void	drawChildren(const ci::ColorA & parentDrawColor); //! Called by drawScene() after draw() and before didDraw(). Implemented at bottom of class.
 	inline virtual void	didDraw() {}							//! Called by drawScene after draw()
 
-	inline virtual void didMoveToView(BaseView* parent) {}		//! Called when moved to a parent
-	inline virtual void willMoveFromView(BaseView* parent) {}	//! Called when removed from a parent
+	inline virtual void didMoveToView(BaseView * parent) {}		//! Called when moved to a parent
+	inline virtual void willMoveFromView(BaseView * parent) {}	//! Called when removed from a parent
 
 	const ci::ColorA& getDrawColor() const { return mDrawColor; }	//! The color used for drawing, which is a composite of the alpha and tint colors.
 
@@ -379,6 +383,7 @@ private:
 	// Misc
 	const size_t							mViewId;
 	const std::string						mViewIdStr;
+	std::string								mName;
 	std::map<std::string, UserInfoTypes>	mUserInfo;
 
 
@@ -390,9 +395,9 @@ private:
 // Inline implementations to improve speed on frequently used methods
 // 
 
-void BaseView::drawChildren(const ci::ColorA& parentTint) {
+void BaseView::drawChildren(const ci::ColorA& parentDrawColor) {
 	for (auto child : mChildren) {
-		child->drawScene(parentTint);
+		child->drawScene(parentDrawColor);
 	}
 }
 

--- a/src/bluecadet/views/EllipseView.cpp
+++ b/src/bluecadet/views/EllipseView.cpp
@@ -69,12 +69,12 @@ ci::gl::GlslProgRef EllipseView::getSharedEllipseProg() {
 
 				in vec4			ciPosition;
 				in vec4			ciColor;
-				out vec4		color;
-				out vec4		normPosition;
+				out vec4		vColor;
+				out vec4		vNormPosition;
 
 				void main(void) {
-					color = ciColor * uBackgroundColor;
-					normPosition = ciPosition;
+					vColor = ciColor * uBackgroundColor;
+					vNormPosition = ciPosition;
 					gl_Position = ciModelViewProjection * vec4(
 						ciPosition.x * uSize.x - uSize.x * 0.5f,
 						ciPosition.y * uSize.y - uSize.y * 0.5f,
@@ -85,12 +85,12 @@ ci::gl::GlslProgRef EllipseView::getSharedEllipseProg() {
 				uniform vec2	uSize;
 				uniform float	uSmoothness;
 
-				in vec4			normPosition;
-				in vec4			color;
+				in vec4			vNormPosition;
+				in vec4			vColor;
 				out vec4		oColor;
 
 				void main(void) {
-					vec2 normalizedDelta = normPosition.xy * 2.0f - vec2(1.0f);
+					vec2 normalizedDelta = vNormPosition.xy * 2.0f - vec2(1.0f);
 					float normalizedRadiusSq = normalizedDelta.x * normalizedDelta.x + normalizedDelta.y * normalizedDelta.y;
 
 					if (normalizedRadiusSq > 1.0f) {
@@ -102,11 +102,11 @@ ci::gl::GlslProgRef EllipseView::getSharedEllipseProg() {
 					float minRadius = max(0, maxRadius - uSmoothness);
 					float radius = maxRadius * normalizedRadius;
 
-					oColor = color;
+					oColor = vColor;
 
 					// interpolate smooth edge
 					float quota = uSmoothness == 0 ? 0 : (maxRadius - radius) / uSmoothness;
-					oColor.w = color.w * smoothstep(0.0f, 1.0f, quota);
+					oColor.a = vColor.a * smoothstep(0.0f, 1.0f, quota);
 				}
 			))
 		);

--- a/src/bluecadet/views/EllipseView.cpp
+++ b/src/bluecadet/views/EllipseView.cpp
@@ -49,15 +49,6 @@ void EllipseView::draw() {
 	batch->draw();
 }
 
-void EllipseView::debugDrawOutline() {
-	gl::ScopedModelMatrix scopedModelMatrix;
-	gl::ScopedViewMatrix scopedViewMatrix;
-
-	gl::translate(-getSize() * 0.5f);
-
-	BaseView::debugDrawOutline();
-}
-
 ci::gl::BatchRef EllipseView::getSharedEllipseBatch() {
 	static ci::gl::BatchRef batch = nullptr;
 	if (!batch) {
@@ -101,7 +92,10 @@ ci::gl::GlslProgRef EllipseView::getSharedEllipseProg() {
 				void main(void) {
 					vec2 normalizedDelta = normPosition.xy * 2.0f - vec2(1.0f);
 					float normalizedRadiusSq = normalizedDelta.x * normalizedDelta.x + normalizedDelta.y * normalizedDelta.y;
-					if (normalizedRadiusSq > 1.0f) discard;
+
+					if (normalizedRadiusSq > 1.0f) {
+						discard;
+					}
 
 					float normalizedRadius = sqrt(normalizedRadiusSq);
 					float maxRadius = length(uSize) * 0.5f;
@@ -111,16 +105,11 @@ ci::gl::GlslProgRef EllipseView::getSharedEllipseProg() {
 					oColor = color;
 
 					// interpolate smooth edge
-					if (uSmoothness > 0 && radius > minRadius) {
-						float quota = (maxRadius - radius) / uSmoothness;
-						oColor.w = color.w * smoothstep(0.0f, 1.0f, quota);
-					}
+					float quota = uSmoothness == 0 ? 0 : (maxRadius - radius) / uSmoothness;
+					oColor.w = color.w * smoothstep(0.0f, 1.0f, quota);
 				}
 			))
 		);
-		prog->uniform("uSize", vec2(0));
-		prog->uniform("uSmoothness", 1.0f);
-		prog->uniform("uBackgroundColor", vec4(0));
 	}
 	return prog;
 }

--- a/src/bluecadet/views/EllipseView.h
+++ b/src/bluecadet/views/EllipseView.h
@@ -27,13 +27,19 @@ public:
 	//! Shorthand for calling setSize(vec2(2.0f * radius))
 	void setRadius(const float radius);
 
+	//! Ellipse bounds extend -radius to +radius both for x and y
+	ci::Rectf getBounds(const bool scaled) override {
+		ci::Rectf bounds = BaseView::getBounds(scaled);
+		bounds.offset(-0.5f * bounds.getSize());
+		return bounds;
+	}
+
 	//! The smoothness of the ellipse's edge
 	ci::Anim<float> &	getSmoothness() { return mSmoothness; }
 	void				setSmoothness(const float value) { mSmoothness = value; invalidate(false, true); }
 
 protected:
 	virtual void draw() override;
-	virtual void debugDrawOutline() override;
 
 	static ci::gl::BatchRef		getSharedEllipseBatch();
 	static ci::gl::GlslProgRef	getSharedEllipseProg();

--- a/src/bluecadet/views/ImageView.cpp
+++ b/src/bluecadet/views/ImageView.cpp
@@ -13,7 +13,8 @@ ImageView::ScaleMode ImageView::sDefaultScaleMode = ImageView::ScaleMode::STRETC
 ImageView::ImageView() : BaseView(),
 mTexture(nullptr),
 mTextureScale(1.0f),
-mScaleMode(sDefaultScaleMode)
+mScaleMode(sDefaultScaleMode),
+mTopDown(false)
 {
 }
 
@@ -99,14 +100,15 @@ void ImageView::draw() {
 		)).fragment(CI_GLSL(150,
 			uniform sampler2D uTex0;
 			uniform vec2 uTexScale;
-			uniform int uPremult;
+			uniform int uTopDown;
 			in vec2 vTexCoord0;
 			in vec4 vColor;
 			out vec4 oColor;
 
 			void main(void) {
-				vec2 texCoord = vec2(vTexCoord0.x, 1.0 - vTexCoord0.y);
-				texCoord = (texCoord - vec2(0.5)) * uTexScale + vec2(0.5);
+				vec2 texCoord = vTexCoord0;
+				texCoord.y = uTopDown != 0 ? 1.0 - texCoord.y : texCoord.y; // flip y if necessary
+				texCoord = (texCoord - vec2(0.5)) * uTexScale + vec2(0.5); // scale around center
 
 				if (texCoord.x < 0 || texCoord.y < 0 || texCoord.x > 1.0 || texCoord.y > 1.0) {
 					discard;
@@ -123,6 +125,7 @@ void ImageView::draw() {
 	mTexture->bind(0);
 	shader->uniform("uTexScale", mTextureScale);
 	shader->uniform("uSize", mTextureSize);
+	shader->uniform("uTopDown", mTopDown ? 1 : 0);
 	batch->draw();
 }
 

--- a/src/bluecadet/views/ImageView.cpp
+++ b/src/bluecadet/views/ImageView.cpp
@@ -113,20 +113,16 @@ void ImageView::draw() {
 				}
 
 				oColor = texture(uTex0, texCoord);
-				oColor.rgb = mix(oColor.rgb, oColor.rgb / oColor.a, uPremult);
-				oColor *= vColor;
+				oColor.rgb /= oColor.a;
 			}
 		)));
 
 		batch = gl::Batch::create(geom::Rect().rect(Rectf(0, 0, 1.0f, 1.0f)), shader);
 	}
 
-	gl::ScopedBlendAlpha scopedBlend;
-
 	mTexture->bind(0);
 	shader->uniform("uTexScale", mTextureScale);
 	shader->uniform("uSize", mTextureSize);
-	shader->uniform("uPremult", getBlendMode() == BlendMode::PREMULT ? 1 : 0);
 	batch->draw();
 }
 

--- a/src/bluecadet/views/ImageView.cpp
+++ b/src/bluecadet/views/ImageView.cpp
@@ -8,9 +8,12 @@ using namespace std;
 namespace bluecadet {
 namespace views {
 
+ImageView::ScaleMode ImageView::sDefaultScaleMode = ImageView::ScaleMode::STRETCH;
+
 ImageView::ImageView() : BaseView(),
 mTexture(nullptr),
-mScaleMode(ScaleMode::NONE)
+mTextureScale(1.0f),
+mScaleMode(sDefaultScaleMode)
 {
 }
 
@@ -19,26 +22,8 @@ ImageView::~ImageView() {
 
 void ImageView::reset() {
     BaseView::reset();
-    clearTexture();
-}
-
-void ImageView::clearTexture() {
-    mTexture = nullptr;
-    mDrawingDestRect = Rectf();
-    mDrawingArea = Area();
-	mScaleMode = ScaleMode::NONE;
-}
-
-void ImageView::setup(const gl::TextureRef texture, const ci::vec2 &size, const ScaleMode scaleMode) {
-	const bool resizeToTexture = size.x == 0 && size.y == 0;
-
-	setScaleMode(scaleMode);
-	
-	setTexture(texture, resizeToTexture);
-
-	if (!resizeToTexture) {
-		setSize(size);
-	}
+    setTexture(nullptr);
+	setScaleMode(sDefaultScaleMode);
 }
 
 void ImageView::setTexture(ci::gl::TextureRef texture, const bool resizeToTexture) {
@@ -57,16 +42,32 @@ void ImageView::setTexture(ci::gl::TextureRef texture, const bool resizeToTextur
 	invalidate(false, true);
 }
 
-void ImageView::setSize(const ci::vec2& size) {
-	BaseView::setSize(size);
+void ImageView::validateContent() {
+	BaseView::validateContent();
 
-	mDrawingDestRect = Rectf(vec2(0), size);
+	mTextureScale = vec2(1.0f);
 
-	if (mTexture) {
-		// Aspect fill drawing area
-		mDrawingArea = Area(mDrawingDestRect.getCenteredFit(mTexture->getBounds(), true));
-	} else {
-		mDrawingArea = Area();
+	switch (mScaleMode) {
+		case ScaleMode::NONE:
+			mTextureScale = vec2(1.0f);
+			mTextureSize = mTexture->getSize();
+			break;
+		case ScaleMode::STRETCH:
+			mTextureScale = vec2(1.0f);
+			mTextureSize = getSize();
+			break;
+		case ScaleMode::FIT:
+		case ScaleMode::COVER:
+		{
+			mTextureSize = getSize();
+			mTextureScale = mTextureSize / vec2(mTexture->getSize());
+			if (mScaleMode == ScaleMode::FIT) {
+				mTextureScale /= glm::min(mTextureScale.x, mTextureScale.y);
+			} else {
+				mTextureScale /= glm::max(mTextureScale.x, mTextureScale.y);
+			}
+			break;
+		}
 	}
 }
 
@@ -74,21 +75,59 @@ void ImageView::draw() {
 	if (!mTexture) return;
 	
 	BaseView::draw();
-	
-	switch (mScaleMode) {
-		case ScaleMode::NONE:
-			gl::draw(mTexture);
-			break;
-		case ScaleMode::STRETCH:
-			gl::draw(mTexture, mDrawingDestRect);
-			break;
-		case ScaleMode::FIT:
-			gl::draw(mTexture, Rectf(mTexture->getBounds()).getCenteredFit(mDrawingDestRect, true));
-			break;
-		case ScaleMode::COVER:
-			gl::draw(mTexture, mDrawingArea, mDrawingDestRect);
-			break;
+
+	static gl::GlslProgRef shader = nullptr;
+	static gl::BatchRef batch = nullptr;
+
+	if (!shader) {
+		shader = gl::GlslProg::create(gl::GlslProg::Format()
+		.vertex(CI_GLSL(150,
+			uniform mat4 ciModelViewProjection;
+			uniform vec2 uSize;
+			in vec4 ciPosition;
+			in vec4 ciColor;
+			in vec2 ciTexCoord0;
+			out vec4 vColor;
+			out vec2 vTexCoord0;
+
+			void main(void) {
+				vColor = ciColor;
+				vTexCoord0 = ciTexCoord0;
+				vec4 pos = ciPosition * vec4(uSize, 0, 1);
+				gl_Position = ciModelViewProjection * pos;
+			}
+		)).fragment(CI_GLSL(150,
+			uniform sampler2D uTex0;
+			uniform vec2 uTexScale;
+			uniform int uPremult;
+			in vec2 vTexCoord0;
+			in vec4 vColor;
+			out vec4 oColor;
+
+			void main(void) {
+				vec2 texCoord = vec2(vTexCoord0.x, 1.0 - vTexCoord0.y);
+				texCoord = (texCoord - vec2(0.5)) * uTexScale + vec2(0.5);
+
+				if (texCoord.x < 0 || texCoord.y < 0 || texCoord.x > 1.0 || texCoord.y > 1.0) {
+					discard;
+				}
+
+				oColor = texture(uTex0, texCoord);
+				oColor.rgb = mix(oColor.rgb, oColor.rgb / oColor.a, uPremult);
+				oColor *= vColor;
+			}
+		)));
+
+		batch = gl::Batch::create(geom::Rect().rect(Rectf(0, 0, 1.0f, 1.0f)), shader);
 	}
+
+	gl::ScopedBlendAlpha scopedBlend;
+
+	mTexture->bind(0);
+	shader->uniform("uTexScale", mTextureScale);
+	shader->uniform("uSize", mTextureSize);
+	shader->uniform("uPremult", getBlendMode() == BlendMode::PREMULT ? 1 : 0);
+	batch->draw();
 }
 
 }

--- a/src/bluecadet/views/ImageView.h
+++ b/src/bluecadet/views/ImageView.h
@@ -32,25 +32,28 @@ public:
 	virtual ~ImageView();
 
 	void reset() override;
-    virtual void clearTexture();
-
-	virtual void setup(const ci::gl::TextureRef texture, const ci::vec2& size = ci::vec2(0), const ScaleMode scaleMode = ScaleMode::COVER);
-
-	virtual void setSize(const ci::vec2& size) override;
 
 	inline ci::gl::TextureRef getTexture() const { return mTexture; }
 	inline void			setTexture(const ci::gl::TextureRef value, const bool resizeToTexture = true);
 
+	//! Defaults to getDefaultScaleMode()
 	inline ScaleMode	getScaleMode() const { return mScaleMode; }
-	inline void			setScaleMode(const ScaleMode scaleMode) { mScaleMode = scaleMode; }
+	inline void			setScaleMode(const ScaleMode scaleMode) { mScaleMode = scaleMode; invalidate(false, true); }
+
+	//! Defaults to STRETCH
+	static ScaleMode	getDefaultScaleMode() { return sDefaultScaleMode; }
+	static void			setDefaultScaleMode(const ScaleMode scaleMode) { sDefaultScaleMode = scaleMode; }
 
 private:
 
-	virtual void draw() override;
+	void draw() override;
+	void validateContent() override;
+	
+	static ScaleMode	sDefaultScaleMode;
 
 	ci::gl::TextureRef	mTexture;
-	ci::Rectf			mDrawingDestRect;
-	ci::Area			mDrawingArea;
+	ci::vec2			mTextureScale;
+	ci::vec2			mTextureSize;
 	ScaleMode			mScaleMode;
 };
 

--- a/src/bluecadet/views/ImageView.h
+++ b/src/bluecadet/views/ImageView.h
@@ -44,6 +44,10 @@ public:
 	static ScaleMode	getDefaultScaleMode() { return sDefaultScaleMode; }
 	static void			setDefaultScaleMode(const ScaleMode scaleMode) { sDefaultScaleMode = scaleMode; }
 
+	//! Defaults to false. Can be set independently of the texture's top-down setting in case you have less control over that.
+	void  setTopDown(const bool value)	{ mTopDown = value; }
+	bool  getTopDown() const			{ return mTopDown; }
+
 private:
 
 	void draw() override;
@@ -55,6 +59,7 @@ private:
 	ci::vec2			mTextureScale;
 	ci::vec2			mTextureSize;
 	ScaleMode			mScaleMode;
+	bool				mTopDown;
 };
 
 }

--- a/src/bluecadet/views/StrokedCircleView.h
+++ b/src/bluecadet/views/StrokedCircleView.h
@@ -34,9 +34,15 @@ public:
 	inline ci::Anim<ci::ColorA> &	getStrokeColor() { return mStrokeColor; }
 	inline void						setStrokeColor(ci::ColorA value) { mStrokeColor = value; invalidate(false, true); }
 
+	//! Circle bounds extend -radius to +radius both for x and y
+	ci::Rectf getBounds(const bool scaled) override {
+		ci::Rectf bounds = BaseView::getBounds(scaled);
+		bounds.offset(-0.5f * bounds.getSize());
+		return bounds;
+	}
+
 protected:
 	virtual void draw() override;
-	virtual void debugDrawOutline() override;
 
 	static ci::gl::BatchRef		getSharedBatch();
 	static ci::gl::GlslProgRef	getSharedProg();

--- a/src/bluecadet/views/TextView.cpp
+++ b/src/bluecadet/views/TextView.cpp
@@ -14,8 +14,7 @@ namespace views {
 TextView::TextView(const ci::gl::Texture::Format & textureFormat) : BaseView(), text::StyledTextLayout(),
 mTextureFormat(textureFormat),
 mTexture(nullptr),
-mAutoRenderEnabled(true)
-{
+mAutoRenderEnabled(true) {
 }
 
 TextView::~TextView() {
@@ -31,7 +30,7 @@ ci::gl::Texture::Format TextView::getDefaultTextureFormat() {
 	return format;
 }
 
-void TextView::setup(const std::wstring& text, const std::string& styleKey, const bool parseText, const float maxWidth) {
+void TextView::setup(const std::wstring & text, const std::string & styleKey, const bool parseText, const float maxWidth) {
 	setMaxWidth(maxWidth);
 
 	if (text.empty()) {
@@ -45,7 +44,7 @@ void TextView::setup(const std::wstring& text, const std::string& styleKey, cons
 	}
 }
 
-void TextView::setup(const std::string& text, const std::string& styleKey, const bool parseText, const float maxWidth) {
+void TextView::setup(const std::string & text, const std::string & styleKey, const bool parseText, const float maxWidth) {
 	setup(text::wideString(text), styleKey, parseText, maxWidth);
 }
 
@@ -108,22 +107,22 @@ void TextView::resetRenderedContent() {
 	mSurface = ci::Surface();
 }
 
-void TextView::setSize(const ci::vec2& size) {
+void TextView::setSize(const ci::vec2 & size) {
 	invalidate();
 	setMaxSize(size);
 }
 
-inline void TextView::setWidth(const float width){
+inline void TextView::setWidth(const float width) {
 	invalidate();
 	setMaxWidth(width);
 }
 
-inline void TextView::setHeight(const float height){
+inline void TextView::setHeight(const float height) {
 	invalidate();
 	setMaxHeight(height);
 }
 
-void TextView::setBlendMode(BlendMode blendMode) {
+void TextView::setBlendMode(const BlendMode blendMode) {
 	if (blendMode != getBlendMode()) {
 		invalidate(false, true);
 	}

--- a/src/bluecadet/views/TextView.h
+++ b/src/bluecadet/views/TextView.h
@@ -48,7 +48,7 @@ public:
 	//! Renders content. If surfaceOnly is false this will render into a texture and has to be called on the main thread. Surfaces can be rendered on a worker thread.
 	void	renderContent(bool surfaceOnly = false, bool alpha = true, bool premultiplied = false, bool force = false);
 	void	resetRenderedContent();
-	void	setBlendMode(BlendMode blendMode) override;
+	void	setBlendMode(const BlendMode blendMode) override;
 
 	//! Sets a fixed size for the text view. Any values below 0 will allow the text view to automatically expand in that direction.
 	inline void		setSize(const ci::vec2& size) override;

--- a/src/bluecadet/views/TextView.h
+++ b/src/bluecadet/views/TextView.h
@@ -28,56 +28,49 @@ typedef std::shared_ptr<class TextView> TextViewRef;
 class TextView : public BaseView, public text::StyledTextLayout {
 
 public:
-	TextView();
+	TextView(const ci::gl::Texture::Format & textureFormat = getDefaultTextureFormat());
 	virtual ~TextView();
 
-	//! Creates a TextViewRef instance. Convenience method that groups a few calls together.
-	static TextViewRef create(const std::string& text = "", const std::string& styleKey = "", const bool parseText = true, const float maxWidth = -1.0f);
-	static TextViewRef create(const std::wstring& text = L"", const std::string& styleKey = "", const bool parseText = true, const float maxWidth = -1.0f);
-
-	static const ci::gl::Texture::Format & getDefaultTextureFormat();	//! Default format used for rendering. Optimized for 100% scale. No mip-mapping.
-	static const ci::gl::Texture::Format & getMipMapTextureFormat();	//! MipMapped format optimized for scaling, but with slightly lower quality at 100%.
+	static ci::gl::Texture::Format getDefaultTextureFormat();
 
 	//! Configures a TextView instance. Convenience method that groups a few calls together.
-	void		setup(const std::wstring& text = L"", const std::string& styleKey = "", const bool parseText = true, const float maxWidth = -1.0f);
-	void		setup(const std::string& text = "", const std::string& styleKey = "", const bool parseText = true, const float maxWidth = -1.0f);
+	void setup(const std::wstring& text = L"", const std::string& styleKey = "", const bool parseText = true, const float maxWidth = -1.0f);
+	void setup(const std::string& text = "", const std::string& styleKey = "", const bool parseText = true, const float maxWidth = -1.0f);
 
-	void		reset() override;
+	void	reset() override;
 
 	//! Use these methods for more granular rendering control. Textures will otherwise automatically be rendered if necessary when draw() is called.
-	bool		getAutoRenderEnabled() const { return mAutoRenderEnabled; }
-	void		setAutoRenderEnabled(const bool value) { mAutoRenderEnabled = value; }
+	bool	getAutoRenderEnabled() const { return mAutoRenderEnabled; }
+	void	setAutoRenderEnabled(const bool value) { mAutoRenderEnabled = value; }
 
-	bool		needsToBeRendered(bool surfaceOnly = false) const;
+	bool	needsToBeRendered(bool surfaceOnly = false) const;
 
 	//! Renders content. If surfaceOnly is false this will render into a texture and has to be called on the main thread. Surfaces can be rendered on a worker thread.
-	void		renderContent(bool surfaceOnly = false, bool alpha = true, bool premultiplied = false, bool force = false);
-	void		resetRenderedContent();
-
-	//! The format used for the texture. Setting this will force a re-render of the texture. Defaults to TextView::getDefaultTextureFormat().
-	void		setTextureFormat(const ci::gl::Texture::Format value) { mTextureFormat = value; mHasInvalidRenderedContent = true; }
-	ci::gl::Texture::Format  getTextureFormat() const { return mTextureFormat; }
-
-	//! Use premultiplied alpha or not. Defaults to false.
-	bool		getPremultiplied() const { return mPremultiplied; }
-	void		setPremultiplied(const bool value) { mPremultiplied = value; mHasInvalidRenderedContent = true; }
+	void	renderContent(bool surfaceOnly = false, bool alpha = true, bool premultiplied = false, bool force = false);
+	void	resetRenderedContent();
+	void	setBlendMode(BlendMode blendMode) override;
 
 	//! Sets a fixed size for the text view. Any values below 0 will allow the text view to automatically expand in that direction.
-	inline void	setSize(const ci::vec2& size) override;
-	inline void	setWidth(const float width) override;
-	inline void	setHeight(const float height) override;
+	inline void		setSize(const ci::vec2& size) override;
+	inline void		setWidth(const float width) override;
+	inline void		setHeight(const float height) override;
+
 
 	//! Returns the actual size of the text including padding.
 	//! In advanced use-cases this can differ from what was set in setSize(), e.g. if a special clip mode is set or size-trimming is enabled.
-	inline const ci::vec2	getSize() override;
+	 inline const ci::vec2	getSize() override;
+
+	 //! The texture format used to create textures.
+	 void							setTextureFormat(const ci::gl::Texture::Format & value) { mTextureFormat = value; }
+	 const ci::gl::Texture::Format &	getTextureFormat() const { return mTextureFormat; }
 
 protected:
 
 	//! Will update the text texture if necessary.
-	void		willDraw() override;
-	void		draw() override;
+	void			willDraw() override;
+	void			draw() override;
 
-	inline void	invalidate(const bool layout = true, const bool size = true) override;
+	inline void		invalidate(const bool layout = true, const bool size = true) override;
 
 	// Change visibility of these methods from public to protected since setSize()/getSize() should be used.
 	const ci::vec2 &	getMaxSize() const override { return StyledTextLayout::getMaxSize(); };
@@ -88,11 +81,11 @@ protected:
 	void				setMaxHeight(const float value) override { return StyledTextLayout::setMaxHeight(value); };
 
 	bool				mHasInvalidRenderedContent;
-	bool				mAutoRenderEnabled;
-	bool				mPremultiplied;
+	bool				mSmoothScalingEnabled = true;
+	bool				mAutoRenderEnabled = true;
 
-	ci::Surface			mSurface;
-	ci::gl::TextureRef	mTexture;
+	ci::Surface				mSurface;
+	ci::gl::TextureRef		mTexture;
 	ci::gl::Texture::Format	mTextureFormat;
 
 };

--- a/src/bluecadet/views/TouchView.cpp
+++ b/src/bluecadet/views/TouchView.cpp
@@ -220,7 +220,7 @@ bool TouchView::containsPoint(const vec2 &point) {
 }
 
 bool TouchView::canAcceptTouch(const bluecadet::touch::Touch & touch) const {
-	return (mMultiTouchEnabled || mTouchIds.empty()) && (getAlphaConst().value() > mMinAlphaForTouches);
+	return (mMultiTouchEnabled || mTouchIds.empty()) && (getAlphaConst() > mMinAlphaForTouches);
 }
 
 bool TouchView::isHandlingTouch(const int touchId) const {


### PR DESCRIPTION
- Fixes premultiplication with EllipseView and StrokedCircleView
- Fixes premultiplication issues with TextView
- Adds more efficient ImageView scale modes via custom shader and better premultiplication support
- Adds name property to BaseView to identify views when debugging (name defaults to view sequential id)
- Adds `getBounds()` method to BaseView to get a rectangle bounding box. This is esp helpful when getting bounds of views with different origins (e.g. EllipseView, with a center origin, and BaseView with an top-left origin)
- Debug outlines (when pressing `b`) now show view names and origin