### PR TITLE
Fix bug in ScreenCamera zooming to a specific location

### DIFF
--- a/src/bluecadet/core/ScreenCamera.cpp
+++ b/src/bluecadet/core/ScreenCamera.cpp
@@ -62,7 +62,7 @@ void ScreenCamera::zoomToFitWindow() {
 	updateViewport();
 }
 
-void ScreenCamera::zoomAtLocation(const float targetScale, const vec2 location) {
+void ScreenCamera::zoomAtCurrentLocation(const float targetScale) {
 	const vec2 currentScale = mPlaceholderView->getScale();
 	const vec2 deltaScale = vec2(targetScale) / currentScale;
 
@@ -73,6 +73,13 @@ void ScreenCamera::zoomAtLocation(const float targetScale, const vec2 location) 
 
 	mPlaceholderView->setScale(targetScale);
 	mPlaceholderView->setPosition(targetPos);
+
+	updateViewport();
+}
+
+void ScreenCamera::zoomAtLocation(const float targetScale, const vec2 location) {
+	mPlaceholderView->setScale(targetScale);
+	mPlaceholderView->setPosition(location);
 	updateViewport();
 }
 
@@ -114,7 +121,7 @@ void ScreenCamera::handleKeyDown(KeyEvent event) {
 			const bool zoomIn = (code == KeyEvent::KEY_KP_PLUS || code == KeyEvent::KEY_PLUS || code == KeyEvent::KEY_EQUALS);
 			const float deltaScale = (zoomIn ? zoomSpeed : 1.0f / zoomSpeed);
 			const float targetScale = mPlaceholderView->getScale().value().x * deltaScale;
-			zoomAtWindowCenter(targetScale);
+			zoomAtCurrentLocation(targetScale);
 			break;
 		}
 		case KeyEvent::KEY_UP:
@@ -151,7 +158,7 @@ void ScreenCamera::handleKeyDown(KeyEvent event) {
 			if (mZoomToggleHotkeyEnabled) {
 				// toggle zoom to fit window
 				if (mPlaceholderView->getScale().value().x != 1.0f) {
-					zoomAtWindowCenter(1.0f);
+					zoomAtCurrentLocation(1.0f);
 				} else {
 					zoomToFitWindow();
 				}

--- a/src/bluecadet/core/ScreenCamera.h
+++ b/src/bluecadet/core/ScreenCamera.h
@@ -44,6 +44,9 @@ public:
 	//! Zooms to fit the display at col/row into the current application window.
 	void				zoomToDisplay(const int row, const int col);
 
+	//! Zooms around the current location
+	void				zoomAtCurrentLocation(const float scale);
+
 	//! Zooms around a location in window coordinate space
 	void				zoomAtLocation(const float scale, const ci::vec2 location);
 


### PR DESCRIPTION
This PR fixes a few issues with  `ScreenCamera`:
- renames `zoomAtLocation()` to `zoomAtCurrentLocation()` since that's what it was actually doing
- adds a simple `zoomAtLocation()`, needed for my use case of "full scale, put content in top left corner"
- replaces a few calls to `zoomAtWindowCenter()` with `zoomAtCurrentLocation()` where that is more semantically correct