### PR TITLE
Wrap Touch-related in `#ifndef NOTOUCH` to support faster builds

### DIFF
--- a/src/bluecadet/core/BaseApp.cpp
+++ b/src/bluecadet/core/BaseApp.cpp
@@ -3,12 +3,20 @@
 #include "ScreenLayout.h"
 #include "ScreenCamera.h"
 
+// Needed for SetForegroundWindow
+#if defined(CINDER_MSW)
+#include <Windows.h>
+#endif
+
 using namespace ci;
 using namespace ci::app;
 using namespace std;
 using namespace bluecadet::views;
+
+#ifndef NOTOUCH
 using namespace bluecadet::touch;
 using namespace bluecadet::touch::drivers;
+#endif
 
 namespace bluecadet {
 namespace core {
@@ -66,6 +74,7 @@ void BaseApp::setup() {
 	gl::enableVerticalSync(settings->mVerticalSync);
 	gl::enableAlphaBlending();
 
+#ifndef NOTOUCH
 	// Set up touches
 	if (settings->mMouseEnabled) {
 		mMouseDriver.connect();
@@ -79,6 +88,7 @@ void BaseApp::setup() {
 	}
 
 	mSimulatedTouchDriver.setup(Rectf(vec2(0), getWindowSize()), 60);
+#endif
 
 	// Debugging
 	mStats->setBackgroundColor(ColorA(0, 0, 0, 0.1f));
@@ -99,7 +109,9 @@ void BaseApp::update() {
 	// touch events to convert touches from window into app space
 	const auto appTransform = glm::inverse(ScreenCamera::getInstance()->getTransform());
 	const auto appSize = ScreenLayout::getInstance()->getAppSize();
+#ifndef NOTOUCH
 	touch::TouchManager::getInstance()->update(mRootView, appSize, appTransform);
+#endif
 	mRootView->updateScene(deltaTime);
 
 	mStats->addValue("FPS", 1.0f / (float)deltaTime);
@@ -118,10 +130,12 @@ void BaseApp::draw(const bool clear) {
 		gl::multModelMatrix(ScreenCamera::getInstance()->getTransform());
 		mRootView->drawScene();
 
+#ifndef NOTOUCH
 		// draw debug touches in app coordinate space
 		if (settings->mDebugEnabled && settings->mShowTouches) {
 			touch::TouchManager::getInstance()->debugDrawTouches();
 		}
+#endif
 	}
 
 	if (settings->mDebugEnabled) {
@@ -199,6 +213,7 @@ void BaseApp::handleViewportChange(const ci::Area & viewport) {
 	SettingsManager::getInstance()->getParams()->setPosition(vec2(mDebugUiPadding));
 }
 
+#ifndef NOTOUCH
 void BaseApp::addTouchSimulatorParams(float touchesPerSecond) {
 
 	mSimulatedTouchDriver.setTouchesPerSecond(touchesPerSecond);
@@ -254,6 +269,7 @@ void BaseApp::addTouchSimulatorParams(float touchesPerSecond) {
 		params->setOptions(groupName, "opened=false");
 	}
 }
+#endif
 
 }
 }

--- a/src/bluecadet/core/BaseApp.cpp
+++ b/src/bluecadet/core/BaseApp.cpp
@@ -13,7 +13,7 @@ using namespace ci::app;
 using namespace std;
 using namespace bluecadet::views;
 
-#ifndef NOTOUCH
+#ifndef NO_TOUCH
 using namespace bluecadet::touch;
 using namespace bluecadet::touch::drivers;
 #endif
@@ -74,7 +74,7 @@ void BaseApp::setup() {
 	gl::enableVerticalSync(settings->mVerticalSync);
 	gl::enableAlphaBlending();
 
-#ifndef NOTOUCH
+#ifndef NO_TOUCH
 	// Set up touches
 	if (settings->mMouseEnabled) {
 		mMouseDriver.connect();
@@ -109,7 +109,7 @@ void BaseApp::update() {
 	// touch events to convert touches from window into app space
 	const auto appTransform = glm::inverse(ScreenCamera::getInstance()->getTransform());
 	const auto appSize = ScreenLayout::getInstance()->getAppSize();
-#ifndef NOTOUCH
+#ifndef NO_TOUCH
 	touch::TouchManager::getInstance()->update(mRootView, appSize, appTransform);
 #endif
 	mRootView->updateScene(deltaTime);
@@ -130,7 +130,7 @@ void BaseApp::draw(const bool clear) {
 		gl::multModelMatrix(ScreenCamera::getInstance()->getTransform());
 		mRootView->drawScene();
 
-#ifndef NOTOUCH
+#ifndef NO_TOUCH
 		// draw debug touches in app coordinate space
 		if (settings->mDebugEnabled && settings->mShowTouches) {
 			touch::TouchManager::getInstance()->debugDrawTouches();
@@ -213,7 +213,7 @@ void BaseApp::handleViewportChange(const ci::Area & viewport) {
 	SettingsManager::getInstance()->getParams()->setPosition(vec2(mDebugUiPadding));
 }
 
-#ifndef NOTOUCH
+#ifndef NO_TOUCH
 void BaseApp::addTouchSimulatorParams(float touchesPerSecond) {
 
 	mSimulatedTouchDriver.setTouchesPerSecond(touchesPerSecond);

--- a/src/bluecadet/core/BaseApp.h
+++ b/src/bluecadet/core/BaseApp.h
@@ -13,7 +13,7 @@
 #include "../views/MiniMapView.h"
 #include "../views/GraphView.h"
 
-#ifndef NOTOUCH
+#ifndef NO_TOUCH
 #include "../touch/TouchManager.h"
 #include "../touch/drivers/MouseDriver.h"
 #include "../touch/drivers/NativeTouchDriver.h"
@@ -54,7 +54,7 @@ public:
 	//! Debug view to render stats like fps in a graph.
 	views::GraphViewRef	getStats() const { return mStats; };
 
-#ifndef NOTOUCH
+#ifndef NO_TOUCH
 	//! The main touch driver running on TUIO. Automatically connected at app launch.
 	touch::drivers::TuioDriver &            getTouchDriver() { return mTuioDriver; }
 
@@ -79,7 +79,7 @@ private:
 	float									mDebugUiPadding;
 	bool									mIsLateSetupCompleted;
 
-#ifndef NOTOUCH
+#ifndef NO_TOUCH
 	touch::drivers::TuioDriver				mTuioDriver;
 	touch::drivers::MouseDriver				mMouseDriver;
 	touch::drivers::NativeTouchDriver		mNativeTouchDriver;

--- a/src/bluecadet/core/BaseApp.h
+++ b/src/bluecadet/core/BaseApp.h
@@ -12,11 +12,14 @@
 #include "../views/BaseView.h"
 #include "../views/MiniMapView.h"
 #include "../views/GraphView.h"
+
+#ifndef NOTOUCH
 #include "../touch/TouchManager.h"
 #include "../touch/drivers/MouseDriver.h"
 #include "../touch/drivers/NativeTouchDriver.h"
 #include "../touch/drivers/TuioDriver.h"
 #include "../touch/drivers/SimulatedTouchDriver.h"
+#endif
 
 namespace bluecadet {
 namespace core {
@@ -51,6 +54,7 @@ public:
 	//! Debug view to render stats like fps in a graph.
 	views::GraphViewRef	getStats() const { return mStats; };
 
+#ifndef NOTOUCH
 	//! The main touch driver running on TUIO. Automatically connected at app launch.
 	touch::drivers::TuioDriver &            getTouchDriver() { return mTuioDriver; }
 
@@ -65,6 +69,7 @@ public:
 
 	//! Adds a set of params to control the touch simulator
 	void		addTouchSimulatorParams(float touchesPerSecond = 50.f);
+#endif
 
 private:
 	views::BaseViewRef						mRootView;
@@ -74,10 +79,13 @@ private:
 	float									mDebugUiPadding;
 	bool									mIsLateSetupCompleted;
 
+#ifndef NOTOUCH
 	touch::drivers::TuioDriver				mTuioDriver;
 	touch::drivers::MouseDriver				mMouseDriver;
 	touch::drivers::NativeTouchDriver		mNativeTouchDriver;
 	touch::drivers::SimulatedTouchDriver	mSimulatedTouchDriver;
+#endif
+
 };
 
 }

--- a/src/bluecadet/views/TouchView.cpp
+++ b/src/bluecadet/views/TouchView.cpp
@@ -1,4 +1,4 @@
-#ifndef NOTOUCH
+#ifndef NO_TOUCH
 
 #include "TouchView.h"
 #include "../touch/TouchManager.h"

--- a/src/bluecadet/views/TouchView.cpp
+++ b/src/bluecadet/views/TouchView.cpp
@@ -1,3 +1,4 @@
+#ifndef NOTOUCH
 
 #include "TouchView.h"
 #include "../touch/TouchManager.h"
@@ -246,3 +247,5 @@ void TouchView::setTouchPath(const float radius, const ci::vec2& offset, const i
 
 }
 }
+
+#endif

--- a/src/bluecadet/views/TouchView.h
+++ b/src/bluecadet/views/TouchView.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef NOTOUCH
+
 #include "cinder/app/App.h"
 #include "cinder/Timeline.h"
 #include "cinder/Shape2d.h"
@@ -201,3 +203,5 @@ private:
 
 }
 }
+
+#endif

--- a/src/bluecadet/views/TouchView.h
+++ b/src/bluecadet/views/TouchView.h
@@ -1,5 +1,5 @@
 #pragma once
-#ifndef NOTOUCH
+#ifndef NO_TOUCH
 
 #include "cinder/app/App.h"
 #include "cinder/Timeline.h"


### PR DESCRIPTION
I had been thinking about this previously in order to avoid needing the Osc & TUIO blocks, but after needing to do rebuilds in VS frequently lately this seemed like a worthwhile effort.

To create/modify a Views project to remove touch support:
- Don't include/remove the `Osc` & `TUIO` blocks from the VS project
- Delete the `bluecadet/touch` folder from the `Views` block
- `TouchView.h/.cpp` can remain in the project - no need to remove that
- Add a `NOTOUCH` preprocessor def to your project (make sure to do both `Debug` & `Release`!)
- Rejoice at your marginally faster but more pure-feeling build process.

I suppose everything in the `bluecadet/touch` folder could also be wrapped in an `#ifndef` so that files don't have to be removed, but it seemed excessive.

And no, of course I didn't measure how much less time it takes.