### PR TITLE
Added support to StrokedRoundedRectView for individual corner control

### DIFF
--- a/samples/ViewTypesSample/src/ViewTypesSampleApp.cpp
+++ b/samples/ViewTypesSample/src/ViewTypesSampleApp.cpp
@@ -98,6 +98,13 @@ void ViewTypesSampleApp::setup() {
 	strokedRoundedRectView->getTimeline()->apply(&strokedRoundedRectView->getCornerRadius(), 50.0f, 2.5f, easeInOutQuad).loop(true).pingPong(true);
 	addViewSample(strokedRoundedRectView, "StrokedRoundedRectView");
 
+	// Uncomment the following lines to tween corners individually
+	//strokedRoundedRectView->useUniformCorners(false);
+	//strokedRoundedRectView->getTimeline()->apply(&strokedRoundedRectView->getTopLeftCornerRadius(), 0.0f, 2.5f, easeInOutQuad).loop(true).pingPong(true);
+	//strokedRoundedRectView->getTimeline()->apply(&strokedRoundedRectView->getTopRightCornerRadius(), 15.0f, 2.5f, easeInOutQuad).loop(true).pingPong(true);
+	//strokedRoundedRectView->getTimeline()->apply(&strokedRoundedRectView->getBottomRightCornerRadius(), 35.0f, 2.5f, easeInOutQuad).loop(true).pingPong(true);
+	//strokedRoundedRectView->getTimeline()->apply(&strokedRoundedRectView->getBottomLeftCornerRadius(), 50.0f, 2.5f, easeInOutQuad).loop(true).pingPong(true);
+
 	//==================================================
 	// EllipseView with variably smooth edges
 	// 

--- a/src/bluecadet/views/StrokedRoundedRectView.h
+++ b/src/bluecadet/views/StrokedRoundedRectView.h
@@ -37,17 +37,36 @@ public:
 	//! Cancels StrokedRoundedRectView animations in addition to BaseView animations.
 	void cancelAnimations() override;
 
+	//! Set view to accept different radii for each corner
+	inline void			useUniformCorners(bool useUniform) { mUniformCorners = useUniform; }
+
+	inline ci::Anim<float> &		getTopLeftCornerRadius() { return mTopLeftRadius; }
+	inline ci::Anim<float> &		getTopRightCornerRadius() { return mTopRightRadius; }
+	inline ci::Anim<float> &		getBottomRightCornerRadius() { return mBottomRightRadius; }
+	inline ci::Anim<float> &		getBottomLeftCornerRadius() { return mBottomLeftRadius; }
+	inline void						setTopLeftCornerRadius(const float value) { mTopLeftRadius = value; invalidate(false, true); }
+	inline void						setTopRightCornerRadius(const float value) { mTopRightRadius = value; invalidate(false, true); }
+	inline void						setBottomRightCornerRadius(const float value) { mBottomRightRadius = value; invalidate(false, true); }
+	inline void						setBottomLeftCornerRadius(const float value) { mBottomLeftRadius = value; invalidate(false, true); }
+	void							setCornerRadii(const float topLeft, const float topRight, const float bottomRight, const float bottomLeft);
+
+
 protected:
 	void draw() override;
 
 	static ci::gl::BatchRef		getSharedBatch();
 	static ci::gl::GlslProgRef	getSharedProg();
 
-	ci::Anim<ci::ColorA> mStrokeColor = ci::ColorA::white();
-	ci::Anim<float> mSmoothness = 1.0f;
-	ci::Anim<float> mStrokeWidth = 1.0f;
-	ci::Anim<float> mCornerRadius = 0.0f;
+	ci::Anim<ci::ColorA>		mStrokeColor = ci::ColorA::white();
+	ci::Anim<float>				mSmoothness = 1.0f;
+	ci::Anim<float>				mStrokeWidth = 1.0f;
+	ci::Anim<float>				mCornerRadius = 0.0f;
 
+	bool						mUniformCorners = true;
+	ci::Anim<float>				mTopLeftRadius = 0.0f;
+	ci::Anim<float>				mTopRightRadius = 0.0f;
+	ci::Anim<float>				mBottomRightRadius = 0.0f;
+	ci::Anim<float>				mBottomLeftRadius = 0.0f;
 };
 
 }


### PR DESCRIPTION
Needed it for WetlandData so I added some ci::Anim's and tweaked the shader to allow for changing the radii of individual corners. See ViewTypesSample app for use case. The conditional in the shader isn't ideal, of course, but I can't imagine any perceivable slowdowns.
