### PR TITLE
Expose FboView's clear color

### DIFF
--- a/src/bluecadet/views/FboView.cpp
+++ b/src/bluecadet/views/FboView.cpp
@@ -11,7 +11,8 @@ FboView::FboView() : BaseView(),
 mFbo(nullptr),
 mForceRedraw(false),
 mDrawsToScreen(true),
-mResolution(1.0f)
+mResolution(1.0f),
+mClearColor(ci::ColorA(0, 0, 0, 0))
 {
 	gl::Texture2d::Format fboTexFormat;
 	fboTexFormat.enableMipmapping(true);
@@ -68,7 +69,7 @@ inline void FboView::validateContent(){
 		gl::ScopedViewport scopedViewport(mFbo->getSize());
 		gl::ScopedFramebuffer scopedFbo(mFbo);
 		
-		gl::clear(ColorA(0, 0, 0, 0));
+		gl::clear(mClearColor);
 		gl::scale(vec3(mResolution, mResolution, 1.0f));
 
 		if (getBlendMode() == BlendMode::PREMULT) {

--- a/src/bluecadet/views/FboView.h
+++ b/src/bluecadet/views/FboView.h
@@ -57,6 +57,10 @@ public:
 	float			getResolution() const { return mResolution; }
 	void			setFboScale(const float value);
 
+	//! Sets the color to be used when clearing the fbo before rendering content
+	void			setClearColor(const ci::ColorA & clearColor) { if (mClearColor != clearColor) { mClearColor = clearColor; invalidate(false, true); } }
+	ci::ColorA		getClearColor() const { return mClearColor; }
+
 protected:
 
 	virtual ci::gl::FboRef	createFbo(const ci::ivec2 & size, const ci::gl::Fbo::Format & format);
@@ -78,6 +82,8 @@ protected:
 
 	ci::gl::Fbo::Format		mFboFormat;
 	ci::gl::FboRef			mFbo; //! Careful, if fbo is invalidated this could be NULL!
+
+	ci::ColorA				mClearColor;
 
 };
 


### PR DESCRIPTION
Calling the setter checks if the new value is different from the current, so in theory you can be sloppy and call this every frame without causing your fbo content to be re-rendered, even though you would never do that :) Does the use of `invalidate(false, true)` look correct in order to for a redraw?