### PR TITLE
Add window position to SettingsManager (JSON + CLI)

### DIFF
--- a/assets/settings.json
+++ b/assets/settings.json
@@ -16,6 +16,7 @@
 			"fullscreen": true,
 			"borderless": false,
 			"size": {"x": 1280, "y": 720},
+			//"pos": {"x": -1, "y": -1}, 		//Window appears centered if no position specified
 			"cameraOffset": {"x": 0, "y": 0},
 			"clearColor": {"r": 0, "g": 0, "b": 0, "a": 1.0}
 		},

--- a/assets/settings.json
+++ b/assets/settings.json
@@ -16,7 +16,6 @@
 			"fullscreen": true,
 			"borderless": false,
 			"size": {"x": 1280, "y": 720},
-			//"pos": {"x": -1, "y": -1}, 		//Window appears centered if no position specified
 			"cameraOffset": {"x": 0, "y": 0},
 			"clearColor": {"r": 0, "g": 0, "b": 0, "a": 1.0}
 		},

--- a/samples/ViewTypesSample/assets/settings.json
+++ b/samples/ViewTypesSample/assets/settings.json
@@ -16,6 +16,7 @@
 			"fullscreen": true,
 			"borderless": false,
 			"size": {"x": 1280, "y": 720},
+			//"pos": {"x": -1, "y": -1},	//Window draws at center if un-declared
 			"cameraOffset": {"x": 0, "y": 0},
 			"clearColor": {"r": 0, "g": 0, "b": 0, "a": 1.0}
 		},

--- a/src/bluecadet/core/SettingsManager.cpp
+++ b/src/bluecadet/core/SettingsManager.cpp
@@ -70,6 +70,14 @@ void SettingsManager::setup(ci::app::App::Settings * appSettings, ci::fs::path j
 			mWindowSize = ivec2(stoi(wStr), stoi(hStr));
 		}
 	});
+	addCommandLineParser("pos", [&](const string &value) {
+		int commaIndex = (int)value.find(",");
+		if (commaIndex != string::npos) {
+			string wStr = value.substr(0, commaIndex);
+			string hStr = value.substr(commaIndex + 1, value.size() - commaIndex - 1);
+			mWindowPos = ivec2(stoi(wStr), stoi(hStr));
+		}
+	});
 	addCommandLineParser("bezel", [&](const string &value) {
 		int commaIndex = (int)value.find(",");
 		if (commaIndex != string::npos) {
@@ -114,8 +122,8 @@ void SettingsManager::parseJson(ci::JsonTree & json) {
 	setFieldFromJsonIfExists(&mBorderless, "settings.window.borderless");
 	setFieldFromJsonIfExists(&mWindowSize.x, "settings.window.size.x");
 	setFieldFromJsonIfExists(&mWindowSize.y, "settings.window.size.y");
-	setFieldFromJsonIfExists(&mWindowPos.x, "settings.window.position.x");
-	setFieldFromJsonIfExists(&mWindowPos.y, "settings.window.position.y");
+	setFieldFromJsonIfExists(&mWindowPos.x, "settings.window.pos.x");
+	setFieldFromJsonIfExists(&mWindowPos.y, "settings.window.pos.y");
 	setFieldFromJsonIfExists(&mCameraOffset.x, "settings.window.cameraOffset.x");
 	setFieldFromJsonIfExists(&mCameraOffset.y, "settings.window.cameraOffset.y");
 	setFieldFromJsonIfExists(&mClearColor.r, "settings.window.clearColor.r");
@@ -173,12 +181,11 @@ void SettingsManager::applyToAppSettings(ci::app::App::Settings * settings) {
 	}
 
 	// Default window position to centered in display if no custom pos has been set
-	if (mWindowPos == ivec2(-1)) {
+	if (mWindowPos == ivec2(INT_MIN)) {
 		ivec2 windowSizeInPx = vec2(settings->getWindowSize()) * pixelScale;
 		ivec2 windowPos = (Display::getMainDisplay()->getSize() - windowSizeInPx) / 2;
 		windowPos = glm::max(windowPos, ivec2(0));
 		settings->setWindowPos(windowPos);
-
 	} else {
 		settings->setWindowPos(vec2(mWindowPos) * pixelScale);
 	}

--- a/src/bluecadet/core/SettingsManager.h
+++ b/src/bluecadet/core/SettingsManager.h
@@ -85,7 +85,7 @@ public:
 
 	// Window
 	ci::ivec2		mWindowSize;						//! The window size on launch
-	ci::ivec2		mWindowPos = ci::ivec2(-1, -1);		//! The window position on launch
+	ci::ivec2		mWindowPos = ci::ivec2(INT_MIN);	//! The window position on launch
 	ci::vec2		mCameraOffset;						//! The offset of the camera on launch
 	ci::ColorA		mClearColor = ci::ColorA::black();	//! The color used when clearing the screen before draw(). Defaults to opaque black.
 


### PR DESCRIPTION
SettingsManager defaults to window centered on screen if no position is set. Wanted the default setting for the block to be a centered window but felt like the position setting line should still be included, so the line is commented out in the settings.json template. Let me know if you prefer another default @benjaminbojko 