### PR TITLE
Invalidate transform after being added to view

### DIFF
--- a/src/bluecadet/views/BaseView.cpp
+++ b/src/bluecadet/views/BaseView.cpp
@@ -121,6 +121,7 @@ void BaseView::addChild(BaseViewRef child, size_t index) {
 		mChildren.insert(it, child);
 	}
 
+	child->invalidate(true, false);
 	child->didMoveToView(this);
 }
 
@@ -135,6 +136,7 @@ void BaseView::removeChild(BaseViewRef child) {
 		return;
 	}
 
+	child->invalidate(true, false);
 	child->willMoveFromView(this);
 	child->mParent = nullptr;
 	mChildren.remove(child);
@@ -150,6 +152,7 @@ void BaseView::removeChild(BaseView* childPtr) {
 }
 
 BaseViewList::iterator BaseView::removeChild(BaseViewList::iterator childIt) {
+	(*childIt)->invalidate(true, false);
 	(*childIt)->willMoveFromView(this);
 	(*childIt)->mParent = nullptr;
 	return mChildren.erase(childIt);

--- a/src/bluecadet/views/BaseView.h
+++ b/src/bluecadet/views/BaseView.h
@@ -338,7 +338,7 @@ protected:
 	inline virtual void	drawChildren(const ci::ColorA & parentDrawColor); //! Called by drawScene() after draw() and before didDraw(). Implemented at bottom of class.
 	inline virtual void	didDraw() {}							//! Called by drawScene after draw()
 
-	inline virtual void didMoveToView(BaseView * parent) { invalidate(true, false); }		//! Called when moved to a parent
+	inline virtual void didMoveToView(BaseView * parent) {}		//! Called when moved to a parent
 	inline virtual void willMoveFromView(BaseView * parent) {}	//! Called when removed from a parent
 
 	const ci::ColorA & getDrawColor() const { return mDrawColor; }	//! The color used for drawing, which is a composite of the alpha and tint colors.

--- a/src/bluecadet/views/BaseView.h
+++ b/src/bluecadet/views/BaseView.h
@@ -338,7 +338,7 @@ protected:
 	inline virtual void	drawChildren(const ci::ColorA & parentDrawColor); //! Called by drawScene() after draw() and before didDraw(). Implemented at bottom of class.
 	inline virtual void	didDraw() {}							//! Called by drawScene after draw()
 
-	inline virtual void didMoveToView(BaseView * parent) {}		//! Called when moved to a parent
+	inline virtual void didMoveToView(BaseView * parent) { invalidate(true, false); }		//! Called when moved to a parent
 	inline virtual void willMoveFromView(BaseView * parent) {}	//! Called when removed from a parent
 
 	const ci::ColorA & getDrawColor() const { return mDrawColor; }	//! The color used for drawing, which is a composite of the alpha and tint colors.

--- a/src/bluecadet/views/TouchView.h
+++ b/src/bluecadet/views/TouchView.h
@@ -78,7 +78,7 @@ public:
 	//! Getters/Setters
 
 	//! Set whether or not to accept new touches. Can be turned on/off.
-	inline void			setTouchEnabled(const bool state)		{ mTouchEnabled = state; };
+	inline void			setTouchEnabled(const bool state)		{ mTouchEnabled = state; if (!state) cancelTouches(); };
 	inline const bool	isTouchEnabled() const					{ return mTouchEnabled; }
 
 	//! Accepts more than one touch if true, otherwise max of one touch if false. Defaults to false.


### PR DESCRIPTION
@benjaminbojko I think that the transform of a view need to be invalidated if this view is added to a new parent. Otherwise, touches might not be captured correctly. Its effective touch area will be the old, wrong one, while the view draws in its new, correct position.