### PR TITLE
Singleton, GraphView and Touch Simulator refactor

### DIFF
--- a/src/bluecadet/core/ScreenCamera.h
+++ b/src/bluecadet/core/ScreenCamera.h
@@ -23,9 +23,8 @@ public:
 	~ScreenCamera();
 
 
-	static ScreenCameraRef getInstance() {
-		static ScreenCameraRef instance = nullptr;
-		if (!instance) instance = ScreenCameraRef(new ScreenCamera());
+	static ScreenCameraRef get() {
+		static auto instance = std::make_shared<ScreenCamera>();
 		return instance;
 	}
 

--- a/src/bluecadet/core/ScreenLayout.h
+++ b/src/bluecadet/core/ScreenLayout.h
@@ -24,9 +24,8 @@ public:
 	~ScreenLayout();
 
 
-	static ScreenLayoutRef getInstance() {
-		static ScreenLayoutRef instance = nullptr;
-		if (!instance) instance = ScreenLayoutRef(new ScreenLayout());
+	static ScreenLayoutRef get() {
+		static auto instance = std::make_shared<ScreenLayout>();
 		return instance;
 	}
 

--- a/src/bluecadet/core/SettingsManager.h
+++ b/src/bluecadet/core/SettingsManager.h
@@ -28,7 +28,7 @@ public:
 	static void setInstance(SettingsManagerRef instance) { sInstance = instance; }
 
 	// Singleton; Instance can be changed by calling setInstance() (e.g. to use subclasses)
-	static SettingsManagerRef getInstance() {
+	static SettingsManagerRef get() {
 		if (!sInstance) {
 			sInstance = std::make_shared<SettingsManager>();
 		}

--- a/src/bluecadet/core/ValueMapping.cpp
+++ b/src/bluecadet/core/ValueMapping.cpp
@@ -9,25 +9,30 @@ using namespace std;
 namespace bluecadet {
 namespace core {
 
-ValueMapping & ValueMapping::param(const std::string & name, const std::string & group, const std::string & key, const std::string & options) {
-	paramName = name;
-	paramGroup = group;
-	paramKey = key;
+ValueMapping & ValueMapping::param(const std::string & name, const std::string & group, const std::string & key,
+								   const std::string & options) {
+	paramName	= name;
+	paramGroup   = group;
+	paramKey	 = key;
 	paramOptions = options;
 	return *this;
 }
 
-ValueMapping& ValueMapping::param(ParamInitFn fn) {
+ValueMapping & ValueMapping::param(ParamInitFn fn) {
 	paramFn = fn;
 	return *this;
 }
+ValueMapping & ValueMapping::hideParam(bool hide) {
+	paramHidden = hide;
+	return *this;
+}
 
-ValueMapping& ValueMapping::commandArg(const std::string & name) {
+ValueMapping & ValueMapping::commandArg(const std::string & name) {
 	commandArgNames.insert(name);
 	return *this;
 }
 
-ValueMapping& ValueMapping::commandArgs(const std::set<std::string> & names) {
+ValueMapping & ValueMapping::commandArgs(const std::set<std::string> & names) {
 	commandArgNames.insert(names.begin(), names.end());
 	return *this;
 }
@@ -44,21 +49,21 @@ JsonTree ValueMapping::toJson(const std::string & key) const {
 			case Type::ValueColor: return JsonTree(key, text::colorToHexStr(getValue<ColorA>(), "#"));
 			case Type::ValueVec2: {
 				const auto value = getValue<vec2>();
-				JsonTree json = JsonTree::makeObject(key);
+				JsonTree json	= JsonTree::makeObject(key);
 				json.addChild(JsonTree("x", value.x));
 				json.addChild(JsonTree("y", value.y));
 				return json;
 			}
 			case Type::ValueIVec2: {
 				const auto value = getValue<ivec2>();
-				JsonTree json = JsonTree::makeObject(key);
+				JsonTree json	= JsonTree::makeObject(key);
 				json.addChild(JsonTree("x", value.x));
 				json.addChild(JsonTree("y", value.y));
 				return json;
 			}
 			case Type::ValueVec3: {
 				const auto value = getValue<vec3>();
-				JsonTree json = JsonTree::makeObject(key);
+				JsonTree json	= JsonTree::makeObject(key);
 				json.addChild(JsonTree("x", value.x));
 				json.addChild(JsonTree("y", value.y));
 				json.addChild(JsonTree("z", value.z));
@@ -66,7 +71,7 @@ JsonTree ValueMapping::toJson(const std::string & key) const {
 			}
 			case Type::ValueIVec3: {
 				const auto value = getValue<ivec3>();
-				JsonTree json = JsonTree::makeObject(key);
+				JsonTree json	= JsonTree::makeObject(key);
 				json.addChild(JsonTree("x", value.x));
 				json.addChild(JsonTree("y", value.y));
 				json.addChild(JsonTree("z", value.z));
@@ -94,13 +99,15 @@ void ValueMapping::readJson(const ci::JsonTree & json) {
 				setValue(vec2(json.getValueForKey<float>(field + ".x"), json.getValueForKey<float>(field + ".y")));
 				break;
 			case Type::ValueVec3:
-				setValue(vec3(json.getValueForKey<float>(field + ".x"), json.getValueForKey<float>(field + ".y"), json.getValueForKey<float>(field + ".z")));
+				setValue(vec3(json.getValueForKey<float>(field + ".x"), json.getValueForKey<float>(field + ".y"),
+							  json.getValueForKey<float>(field + ".z")));
 				break;
 			case Type::ValueIVec2:
 				setValue(ivec2(json.getValueForKey<int>(field + ".x"), json.getValueForKey<int>(field + ".y")));
 				break;
 			case Type::ValueIVec3:
-				setValue(ivec3(json.getValueForKey<int>(field + ".x"), json.getValueForKey<int>(field + ".y"), json.getValueForKey<int>(field + ".z")));
+				setValue(ivec3(json.getValueForKey<int>(field + ".x"), json.getValueForKey<int>(field + ".y"),
+							   json.getValueForKey<int>(field + ".z")));
 				break;
 			default: CI_LOG_E("Unsupported type for field '" << field << "'"); break;
 		}
@@ -108,7 +115,7 @@ void ValueMapping::readJson(const ci::JsonTree & json) {
 		CI_LOG_EXCEPTION("Could not read json field '" << field << "'", e);
 	}
 }
-void ValueMapping::readCommandArg(const std::string& argValue) {
+void ValueMapping::readCommandArg(const std::string & argValue) {
 	try {
 		switch (type) {
 			case Type::ValueBool: setValue(argValue == "true"); break;
@@ -129,7 +136,7 @@ void ValueMapping::readCommandArg(const std::string& argValue) {
 	}
 }
 void ValueMapping::attachToParams(ci::params::InterfaceGlRef params) {
-	if (paramName.empty()) {
+	if (paramName.empty() || paramHidden) {
 		return;
 	}
 
@@ -143,8 +150,8 @@ void ValueMapping::attachToParams(ci::params::InterfaceGlRef params) {
 		case Type::ValueColor: initParam<ColorA>(params); break;
 		case Type::ValueVec2: initParam<vec3>(params); break;
 		case Type::ValueVec3: initParam<vec3>(params); break;
-		//case Type::ValueIVec2: initParam<ivec2>(params); break;
-		//case Type::ValueIVec3: initParam<ivec3>(params); break;
+		// case Type::ValueIVec2: initParam<ivec2>(params); break;
+		// case Type::ValueIVec3: initParam<ivec3>(params); break;
 		default: CI_LOG_E("Params are not supported for field '" << field << "'"); break;
 	}
 
@@ -163,7 +170,7 @@ ci::vec2 ValueMapping::strToVec2(const std::string & str) {
 	return result;
 }
 
-ci::ivec2 ValueMapping::strToIVec2(const std::string& str) {
+ci::ivec2 ValueMapping::strToIVec2(const std::string & str) {
 	ci::ivec2 result;
 	auto segments = text::split(str, ',');
 	if (segments.size() == 2) {
@@ -192,7 +199,7 @@ ci::vec3 ValueMapping::strToVec3(const std::string & str) {
 	return result;
 }
 
-ci::ivec3 ValueMapping::strToIVec3(const std::string& str) {
+ci::ivec3 ValueMapping::strToIVec3(const std::string & str) {
 	ci::ivec3 result;
 	auto segments = text::split(str, ',');
 	if (segments.size() == 3) {

--- a/src/bluecadet/core/ValueMapping.h
+++ b/src/bluecadet/core/ValueMapping.h
@@ -64,6 +64,7 @@ struct ValueMapping {
 						 const std::string & options = "");
 
 	ValueMapping & param(ParamInitFn fn);
+	ValueMapping & hideParam(bool hide = true);
 
 
 	ValueMapping & commandArg(const std::string & name);
@@ -87,6 +88,7 @@ struct ValueMapping {
 	std::string paramGroup;
 	std::string paramKey;
 	std::string paramOptions;
+	bool paramHidden = false;
 	ParamInitFn paramFn = nullptr;  // If this is set, param name, group and key
 									// will be ignored
 
@@ -118,6 +120,9 @@ inline void ValueMapping::initParam(ci::params::InterfaceGlRef params) {
 	}
 	if (!paramKey.empty()) {
 		options.key(paramKey);
+	}
+	if (paramHidden) {
+		options.setVisible(!paramHidden);
 	}
 }
 

--- a/src/bluecadet/touch/TouchManager.cpp
+++ b/src/bluecadet/touch/TouchManager.cpp
@@ -2,6 +2,7 @@
 #include "boost/lexical_cast.hpp"
 #include "cinder/app/RendererGl.h"
 #include "cinder/gl/gl.h"
+#include "cinder/gl/TextureFont.h"
 
 namespace bluecadet {
 namespace touch {
@@ -24,11 +25,8 @@ TouchManager::TouchManager() :
 TouchManager::~TouchManager() {
 }
 
-TouchManagerRef TouchManager::getInstance() {
-	static TouchManagerRef instance = nullptr;
-	if (!instance) {
-		instance = TouchManagerRef(new TouchManager());
-	}
+TouchManagerRef TouchManager::get() {
+	static auto instance = std::make_shared<TouchManager>();
 	return instance;
 }
 
@@ -295,6 +293,7 @@ TouchView * TouchManager::getTopViewForTouch(const Touch & touch, BaseViewRef vi
 void TouchManager::debugDrawTouch(const Touch & touch, const bool isVirtual) {
 	static const ColorA labelColor = ColorA(1, 1, 1, 0.75f);
 	static const Font labelFont = Font("Arial", 16.0f);
+	static const gl::TextureFontRef textureFont = gl::TextureFont::create(labelFont);
 	static const float innerRadius = 12.0f;
 	static const float outerRadius = 16.0f;
 
@@ -369,9 +368,11 @@ void TouchManager::debugDrawTouch(const Touch & touch, const bool isVirtual) {
 	const auto fbo = isVirtual ? fboVirtual : fboNormal;
 	const auto color = isVirtual ? circleColorVirtual : circleColorNormal;
 
-	gl::ScopedColor scopedColor(color);
+	gl::ScopedColor scpopedFboColor(color);
 	gl::draw(fbo->getColorTexture(), circleDestRect);
-	gl::drawString(labelText, labelOffset, labelColor, labelFont);
+
+	gl::ScopedColor scopedLabelColor(labelColor);
+	textureFont->drawString(labelText, labelOffset);
 }
 
 void TouchManager::debugDrawTouches() {

--- a/src/bluecadet/touch/TouchManager.h
+++ b/src/bluecadet/touch/TouchManager.h
@@ -39,7 +39,8 @@ public:
 	//
 
 	//! Shared singleton instance
-	static TouchManagerRef getInstance();
+	static TouchManagerRef get();
+	TouchManager();
 	virtual ~TouchManager();
 
 	void					update(views::BaseViewRef rootView, const ci::vec2 & appSize, const ci::mat4 & appTransform = ci::mat4());
@@ -89,9 +90,6 @@ public:
 
 
 protected:
-	//! Private to make the TouchManager a singleton
-	TouchManager();
-
 
 	//==================================================
 	// Internal Helpers

--- a/src/bluecadet/touch/drivers/MouseDriver.cpp
+++ b/src/bluecadet/touch/drivers/MouseDriver.cpp
@@ -43,7 +43,7 @@ void MouseDriver::connect() {
 
 	mUpdateConnection = App::get()->getSignalUpdate().connect(-1, bind(&MouseDriver::handleUpdate, this));
 
-	mTouchManager = TouchManager::getInstance();
+	mTouchManager = TouchManager::get();
 }
 
 void MouseDriver::disconnect() {

--- a/src/bluecadet/touch/drivers/MultiNativeTouchDriver.cpp
+++ b/src/bluecadet/touch/drivers/MultiNativeTouchDriver.cpp
@@ -247,7 +247,7 @@ void MultiNativeTouchDriver::connect() {
 		std::bind(&MultiNativeTouchDriver::nativeTouchEnded, this, std::placeholders::_1, std::placeholders::_2));
 
 	// Shared pointer to the Touch Manager
-	mTouchManager = TouchManager::getInstance();
+	mTouchManager = TouchManager::get();
 }
 
 MultiNativeTouchDriver::~MultiNativeTouchDriver() {

--- a/src/bluecadet/touch/drivers/NativeTouchDriver.cpp
+++ b/src/bluecadet/touch/drivers/NativeTouchDriver.cpp
@@ -17,7 +17,7 @@ void NativeTouchDriver::connect() {
 	mTouchEndConnection = getWindow()->getSignalTouchesEnded().connect(std::bind(&NativeTouchDriver::nativeTouchEnded, this, std::placeholders::_1));
 
 	// Shared pointer to the Touch Manager
-	mTouchManager = TouchManager::getInstance();
+	mTouchManager = TouchManager::get();
 }
 
 NativeTouchDriver::~NativeTouchDriver() {

--- a/src/bluecadet/touch/drivers/SimulatedTouchDriver.h
+++ b/src/bluecadet/touch/drivers/SimulatedTouchDriver.h
@@ -50,22 +50,23 @@ private:
 	};
 
 	void update();
-	void touchSimulationLoop(); //! Called regularly when connected
 
 	bool mIsRunning;
 
-	ci::Rectf mBounds;
 	float mTouchesPerSecond;
+	float mTouchesToSpawn;
+	double mPrevUpdateTime;
+	int mTouchCounter;
+
+	ci::Rectf mBounds;
+
 	float mMinTouchDuration;
 	float mMaxTouchDuration;
 	float mMinDragDistance;
 	float mMaxDragDistance;
 
-	int touchCounter;
-	ci::signals::Connection	mConnection;
 	ci::TimelineRef	mTimeline;
-	ci::CueRef mSimLoopCue;
-
+	ci::signals::Connection	mConnection;
 	std::map<int, SimulatedTouch> mSimulatedTouches;
 };
 

--- a/src/bluecadet/touch/drivers/TuioDriver.cpp
+++ b/src/bluecadet/touch/drivers/TuioDriver.cpp
@@ -14,7 +14,7 @@ TuioDriver::TuioDriver() :
 	mWindowPos(getWindowPos()),
 	mDisplaySize(getWindow()->getDisplay()->getSize()),
 	mTuio(getWindow(), &mOscReceiver),
-    mTouchManager(touch::TouchManager::getInstance())
+    mTouchManager(touch::TouchManager::get())
 {
 }
 

--- a/src/bluecadet/views/BaseView.cpp
+++ b/src/bluecadet/views/BaseView.cpp
@@ -394,6 +394,7 @@ void BaseView::draw() {
 
 inline void BaseView::drawDebugInfo() {
 	static const Font labelFont = Font("Arial", 20);
+	static const gl::TextureFontRef textureFont = gl::TextureFont::create(labelFont);
 	static const vec2 labelPos = vec2(0, 0);
 	static const float crosshairRadius = 4.0f;
 	static const float transformOriginRadius = 4.0f;
@@ -412,11 +413,11 @@ inline void BaseView::drawDebugInfo() {
 	// draw origin
 	gl::drawLine(vec2(-crosshairRadius, -crosshairRadius), vec2(crosshairRadius, crosshairRadius));
 	gl::drawLine(vec2(-crosshairRadius, crosshairRadius), vec2(crosshairRadius, -crosshairRadius));
-	
+
 	if (!mDebugIncludeClassName) {
-		gl::drawString(mName, labelPos, color, labelFont);
+		textureFont->drawString(mName, labelPos);
 	} else {
-		gl::drawString(mName + " (" + getClassName() + ")", labelPos, color, labelFont);
+		textureFont->drawString(mName + " (" + getClassName() + ")", labelPos);
 	}
 }
 

--- a/src/bluecadet/views/GraphView.cpp
+++ b/src/bluecadet/views/GraphView.cpp
@@ -1,5 +1,9 @@
 #include "GraphView.h"
 
+#include "cinder/Log.h"
+
+#include "cinder/gl/TextureFont.h"
+
 #include <algorithm>
 
 using namespace ci;
@@ -9,92 +13,158 @@ using namespace std;
 namespace bluecadet {
 namespace views {
 
-GraphView::GraphView(const ci::ivec2 & size, const Style style) : BaseView(),
-mNeedsUpdate(false),
-mLabelsEnabled(true),
-mCapacity(size.x),
-mStyle(style)
-{
-	gl::Texture::Format texFormat;
-	texFormat
-		.internalFormat(GL_RGBA)
-		.mipmap(false)
-		.minFilter(GL_LINEAR)
-		.magFilter(GL_NEAREST);
+GraphView::GraphView(const ci::ivec2 & size, const Style style, const Layout layout)
+	: BaseView(),
+	  mNeedsUpdate(false),
+	  mLabelsEnabled(true),
+	  mCapacity(size.x),
+	  mStyle(style),
+	  mLayout(layout),
+	  mLabelFont("Consolas", 16) {
+	mLabelTextureFont = gl::TextureFont::create(mLabelFont);
 
-	gl::Fbo::Format fboFormat;
-	fboFormat
-		.colorTexture(texFormat)
-		.disableDepth();
-
-	if (mCapacity <= 0) {
-		console() << "GraphView: Error: Size must be wider and taller than 0" << endl;
-		return;
-	};
-
-	mFbo = ci::gl::Fbo::create(size.x, size.y, fboFormat);
-
-	BaseView::setSize(mFbo->getSize());
-
-	setupShaders((int)mCapacity);
+	setBackgroundColor(ColorA(0, 0, 0, 0.25f));
+	GraphView::setSize(size);
 }
 
 GraphView::~GraphView() {
 }
 
-void GraphView::addGraph(const std::string & id, const float min, const float max) {
-	addGraph(id, min, max, ci::ColorA(0.0f, 1.0f, 0, 0.5f), ci::ColorA(1.0f, 0.0f, 0, 0.5f));
+void GraphView::addGraph(const std::string & id, const float min, const float max, const bool hidden) {
+	addGraph(id, min, max, ci::ColorA(0.0f, 1.0f, 0, 0.5f), ci::ColorA(1.0f, 0.0f, 0, 0.5f), hidden);
 }
 
-void GraphView::addGraph(const std::string& id, const float min, const float max, const ci::ColorA color) {
-	addGraph(id, min, max, color, color);
+void GraphView::addGraph(const std::string & id, const float min, const float max, const ci::ColorA color,
+						 const bool hidden) {
+	addGraph(id, min, max, color, color, hidden);
 }
 
-void GraphView::addGraph(const std::string& id, const float min, const float max, const ci::ColorA minColor, const ci::ColorA maxColor) {
+void GraphView::addGraph(const std::string & id, const float min, const float max, const ci::ColorA minColor,
+						 const ci::ColorA maxColor, const bool hidden) {
+	if (mGraphs.find(id) != mGraphs.end()) {
+		CI_LOG_W("Graph already exists for id '" << id << "'");
+		return;
+	}
 	Graph graph;
-	graph.min = min;
-	graph.max = max;
+	graph.min	  = min;
+	graph.max	  = max;
 	graph.minColor = minColor;
 	graph.maxColor = maxColor;
-	graph.values = vector<float>(mCapacity, 0.0f);
-	graph.index = 0;
-	mGraphs[id] = graph;
+	graph.hidden   = hidden;
+	graph.values   = vector<float>(mCapacity, 0.0f);
+	graph.index	= 0;
+	mGraphs[id]	= graph;
+	mGraphIdsInOrder.push_back(id);
 	mNeedsUpdate = true;
+}
+
+void GraphView::removeGraph(const std::string & id) {
+	for (auto it = mGraphIdsInOrder.begin(); it != mGraphIdsInOrder.end();) {
+		if (*it == id) {
+			mGraphs.erase(*it);
+			it = mGraphIdsInOrder.erase(it);
+		} else {
+			it++;
+		}
+	}
 }
 
 void GraphView::addValue(const std::string & id, const float value) {
 	auto it = mGraphs.find(id);
 	if (it == mGraphs.end()) {
-		console() << "GraphView: Warning: No graph found with id '" << id << "'" << endl;
+		CI_LOG_W("No graph found with id '" << id << "'");
 		return;
 	}
 	if (mCapacity <= 0) {
 		return;
 	}
-	Graph & graph = it->second;
-	graph.values[mCapacity - graph.index - 1] = value;
-	graph.index = (graph.index + 1) % mCapacity;
-	mNeedsUpdate = true;
+	Graph & graph		  = it->second;
+	auto currIdx		  = mCapacity - graph.index - 1;
+	auto nextIdx		  = (graph.index + 1) % mCapacity;
+	graph.values[currIdx] = value;
+	graph.index			  = nextIdx;
+	mNeedsUpdate		  = true;
 }
 
 void GraphView::setValues(const std::string & id, const std::vector<float> & values) {
 	if (values.size() != mCapacity) {
-		console() << "GraphView: Warning: Values must be an array of size '" << mCapacity << "' and not '" << to_string(values.size()) << "'" << endl;
+		CI_LOG_W("Values must be an array of size '" << mCapacity << "' and not '" << to_string(values.size()) << "'");
 		return;
 	}
 	auto it = mGraphs.find(id);
 	if (it == mGraphs.end()) {
-		console() << "GraphView: Warning: No graph found with id '" << id << "'" << endl;
+		CI_LOG_W("No graph found with id '" << id << "'");
 		return;
 	}
 	it->second.values = values;
+	mNeedsUpdate	  = true;
+}
+
+void GraphView::setSize(const ci::vec2 & size) {
+	BaseView::setSize(size);
+
+	gl::Texture::Format texFormat;
+	gl::Fbo::Format fboFormat;
+
+	texFormat.internalFormat(GL_RGBA).mipmap(false).minFilter(GL_LINEAR).magFilter(GL_NEAREST);
+	fboFormat.colorTexture(texFormat).disableDepth();
+
+	mFbo = ci::gl::Fbo::create(size.x, size.y, fboFormat);
+	setupShaders((int)mCapacity);
+
 	mNeedsUpdate = true;
+}
+
+void GraphView::showGraph(const std::string & id, bool showing) {
+	auto it = mGraphs.find(id);
+	if (it == mGraphs.end()) {
+		CI_LOG_W("No graph found with id '" << id << "'");
+		return;
+	}
+	it->second.hidden = !showing;
+	mNeedsUpdate	  = true;
+}
+
+bool GraphView::isShowing(const std::string & id) const {
+	auto it = mGraphs.find(id);
+	if (it == mGraphs.end()) {
+		CI_LOG_W("No graph found with id '" << id << "'");
+		return false;
+	}
+	return !it->second.hidden;
 }
 
 void GraphView::draw() {
 	if (!mFbo) return;
+
 	render();
 	gl::draw(mFbo->getColorTexture());
+
+	const float lineHeight = mLabelFont.getSize();
+	vec2 labelPos		   = mLabelOffset + vec2(0, getHeight());
+
+	if (!mLabelsEnabled) {
+		return;
+	}
+
+	for (auto idIt = mGraphIdsInOrder.rbegin(); idIt != mGraphIdsInOrder.rend(); ++idIt) {
+		const auto graphIt = mGraphs.find(*idIt);
+		const auto & graph = graphIt->second;
+		if (graph.hidden) {
+			continue;
+		}
+		const int index		   = (int)((mCapacity - graph.index) % mCapacity);
+		const float value	  = graph.values[index];
+		const string labelText = graphIt->first + ": " + to_string(value);
+		gl::ScopedColor labelColor(graph.maxColor);
+		if (mLayout == Layout::LabelsLeft) {
+			const vec2 labelSize = mLabelTextureFont->measureString(labelText);
+			mLabelTextureFont->drawString(labelText, labelPos + labelSize * vec2(-1.0f, 0.0f));
+		} else {
+			mLabelTextureFont->drawString(labelText, labelPos);
+		}
+		labelPos.y -= lineHeight;
+	}
 }
 
 inline void GraphView::render() {
@@ -109,13 +179,14 @@ inline void GraphView::render() {
 
 	mFbo->bindFramebuffer();
 
-	gl::clear(ColorA(0, 0, 0, 0.25));
+	gl::clear(getBackgroundColor());
 
-	static const Font labelFont("Arial", 16);
-	vec2 labelPos(0, getSize().y);
-
-	for (const auto & graphPair : mGraphs) {
-		const auto & graph = graphPair.second;
+	for (const auto & graphId : mGraphIdsInOrder) {
+		const auto graphIt = mGraphs.find(graphId);
+		const auto & graph = graphIt->second;
+		if (graph.hidden) {
+			continue;
+		}
 		mGlsl->uniform("uMinColor", graph.minColor);
 		mGlsl->uniform("uMaxColor", graph.maxColor);
 		mGlsl->uniform("uSize", mFbo->getSize());
@@ -125,15 +196,6 @@ inline void GraphView::render() {
 		mGlsl->uniform("uValues", graph.values.data(), (int)graph.values.capacity());
 		mGlsl->uniform("uStyle", mStyle == Style::Line ? 0 : 1);
 		mBatch->draw();
-
-		if (mLabelsEnabled) {
-			labelPos.y -= labelFont.getSize();
-			const int index = (int)((mCapacity - graph.index) % mCapacity);
-			const float value = graph.values[index];
-			const ColorA labelColor = graph.maxColor;
-			const string labelText = graphPair.first + ": " + to_string(value);
-			gl::drawString(labelText, labelPos, labelColor, labelFont);
-		}
 	}
 
 	mFbo->unbindFramebuffer();
@@ -143,68 +205,54 @@ inline void GraphView::render() {
 
 void GraphView::setupShaders(const int numValues) {
 	try {
-		string vert = CI_GLSL(150,
-			uniform mat4 ciModelViewProjection;
-			uniform ivec2 uSize;
-			in vec4 ciPosition;
-			out vec4 vPosition;
-			void main(void) {
-				vPosition = ciPosition;
-				gl_Position = ciModelViewProjection * (ciPosition * vec4(uSize, 1, 1));
-			}
-		);
+		string vert = CI_GLSL(150, uniform mat4 ciModelViewProjection; uniform ivec2 uSize; in vec4 ciPosition;
+							  out vec4 vPosition; void main(void) {
+								  vPosition   = ciPosition;
+								  gl_Position = ciModelViewProjection * (ciPosition * vec4(uSize, 1, 1));
+							  });
 		string frag = CI_GLSL(150,
-			uniform ivec2 uSize;
-			uniform int uStyle; // 0 = line, 1 = gradient
-			uniform vec4 uMinColor = vec4(0, 1, 0, 1);
-			uniform vec4 uMaxColor = vec4(1, 0, 0, 1);
-			uniform float uValues[NUM_VALUES];
-			uniform int uIndex = 0;
-			uniform float uMin = 0.0;
-			uniform float uMax = 1.0;
-			in vec4 vPosition;
-			out vec4 oColor;
+							  uniform ivec2 uSize;
+							  uniform int uStyle;  // 0 = line, 1 = gradient
+							  uniform vec4 uMinColor = vec4(0, 1, 0, 1); uniform vec4 uMaxColor = vec4(1, 0, 0, 1);
+							  uniform float uValues[NUM_VALUES]; uniform int uIndex = 0; uniform float uMin = 0.0;
+							  uniform float uMax = 1.0; in vec4 vPosition; out vec4 oColor;
 
-			void main(void) {
-				float range = uMax - uMin;
+							  void main(void) {
+								  float range = uMax - uMin;
 
-				if (NUM_VALUES <= 0 || range == 0) {
-					discard;
-				}
+								  if (NUM_VALUES <= 0 || range == 0) {
+									  discard;
+								  }
 
-				int column = int(vPosition.x * float(NUM_VALUES));
-				int index = NUM_VALUES - int(mod(uIndex + column, NUM_VALUES)) - 1;
-				float value = (uValues[index] - uMin) / range;
-				float y = 1.0 - vPosition.y;
-				float pxHeight = 1.0 / uSize.y;
+								  int column	 = int(vPosition.x * float(NUM_VALUES));
+								  int index		 = NUM_VALUES - int(mod(uIndex + column, NUM_VALUES)) - 1;
+								  float value	= clamp((uValues[index] - uMin) / range, 0, 1.0);
+								  float y		 = 1.0 - vPosition.y;
+								  float pxHeight = 1.0 / uSize.y;
 
-				if (value < y) {
-					discard;
+								  if (value < y) {
+									  discard;
 
-				} else if (uStyle == 0 && value <= y + pxHeight) {
-					// line
-					oColor = mix(uMinColor, uMaxColor, y);
+								  } else if (uStyle == 0 && value <= y + pxHeight) {
+									  // line
+									  oColor = mix(uMinColor, uMaxColor, y);
 
-				} else if (uStyle == 1) {
-					// gradient
-					oColor = mix(uMinColor, uMaxColor, y);
-				}
-			}
-		);
+								  } else if (uStyle == 1) {
+									  // gradient
+									  oColor = mix(uMinColor, uMaxColor, y);
+								  }
+							  });
 
-		mGlsl = gl::GlslProg::create(gl::GlslProg::Format()
-			.vertex(vert)
-			.fragment(frag)
-			.define("NUM_VALUES " + to_string(numValues))
-		);
+		mGlsl = gl::GlslProg::create(
+			gl::GlslProg::Format().vertex(vert).fragment(frag).define("NUM_VALUES " + to_string(numValues)));
 		mBatch = gl::Batch::create(geom::Rect(Rectf(0, 0, 1, 1)), mGlsl);
 
 	} catch (Exception e) {
-		console() << "Could not set up shaders: " << e.what() << endl;
-		mGlsl = nullptr;
+		CI_LOG_EXCEPTION("Could not set up shaders", e);
+		mGlsl  = nullptr;
 		mBatch = nullptr;
 	}
 }
 
-}
-}
+}  // namespace views
+}  // namespace bluecadet

--- a/src/bluecadet/views/GraphView.h
+++ b/src/bluecadet/views/GraphView.h
@@ -3,6 +3,8 @@
 #include "cinder/app/RendererGl.h"
 #include "cinder/gl/gl.h"
 
+#include "cinder/gl/TextureFont.h"
+
 #include "BaseView.h"
 
 namespace bluecadet {
@@ -13,65 +15,86 @@ typedef std::shared_ptr<class GraphView> GraphViewRef;
 class GraphView : public views::BaseView {
 
 public:
+	enum class Style { Line, Gradient };
+	enum class Layout { LabelsLeft, LabelsRight };
 
-	enum class Style {
-		Line,
-		Gradient
-	};
-
-	GraphView(const ci::ivec2 & size, const Style style = Style::Line);
+	GraphView(const ci::ivec2 & size = ci::ivec2(128, 48), const Style style = Style::Line,
+			  const Layout layout = Layout::LabelsRight);
 	~GraphView();
 
 	//! Creates a graph with green min and red max colors
-	void addGraph(const std::string & id, const float min, const float max);
+	void addGraph(const std::string & id, const float min, const float max, const bool hidden = false);
 
 	//! Creates a graph with the same min and max colors
-	void addGraph(const std::string & id, const float min, const float max, const ci::ColorA color);
+	void addGraph(const std::string & id, const float min, const float max, const ci::ColorA color,
+				  const bool hidden = false);
 
 	//! Creates a graph with custom min and max colors
-	void addGraph(const std::string & id, const float min, const float max, const ci::ColorA minColor, const ci::ColorA maxColor);
-	
+	void addGraph(const std::string & id, const float min, const float max, const ci::ColorA minColor,
+				  const ci::ColorA maxColor, const bool hidden = false);
+
+	//! Removes a graph if it exists
+	void removeGraph(const std::string & id);
+
 	//! Adds a value to the end of the graph and scrolls the previous values to the left.
 	void addValue(const std::string & id, const float value);
 
 	//! Replaces all current values and resets the scroll position.
 	void setValues(const std::string & id, const std::vector<float> & values);
 
-	//! Size can't be changed using setSize().
-	void setSize(const ci::vec2 & size) override { ci::app::console() << "GraphView: Warning: Size can't be changed using setSize()." << std::endl; }
+	//! This re-creates the FBO and shaders, so this is an expensive method.
+	void setSize(const ci::vec2 & size) override;
 
 	//! Draws labels with the current values of each graph if enabled. Defaults to true.
 	bool getLabelsEnabled() const { return mLabelsEnabled; }
 	void setLabelsEnabled(const bool value) { mLabelsEnabled = value; }
 
+	void showGraph(const std::string & id, bool showing = true);
+	bool isShowing(const std::string & id) const;
+
 	Style getStyle() const { return mStyle; }
 	void setStyle(const Style value) { mStyle = value; }
 
-protected:
+	inline void setLabelOffset(ci::vec2 value) { mLabelOffset = value; }
+	inline ci::vec2 getLabelOffset() const { return mLabelOffset; }
 
+	inline void setLabelFont(ci::Font value) { mLabelFont = value; }
+	inline ci::Font getLabelFont() const { return mLabelFont; }
+
+	inline void setLayout(Layout value) { mLayout = value; }
+	inline Layout getLayout() const { return mLayout; }
+
+protected:
 	struct Graph {
 		ci::ColorA minColor;
 		ci::ColorA maxColor;
-		float min;
-		float max;
+		float min   = 0.0f;
+		float max   = 1.0f;
+		bool hidden = false;
 		std::vector<float> values;
-		size_t index;
+		size_t index = 0;
 	};
 
 	void draw() override;
 	void render();
 	void setupShaders(const int numValues);
 
+	std::vector<std::string> mGraphIdsInOrder;
 	std::map<std::string, Graph> mGraphs;
 	size_t mCapacity;
 	bool mNeedsUpdate;
 	bool mLabelsEnabled;
+	ci::vec2 mLabelOffset;
 	Style mStyle;
+	Layout mLayout;
 
 	ci::gl::FboRef mFbo;
 	ci::gl::GlslProgRef mGlsl;
 	ci::gl::BatchRef mBatch;
+
+	ci::Font mLabelFont;
+	ci::gl::TextureFontRef mLabelTextureFont;
 };
 
-}
-}
+}  // namespace views
+}  // namespace bluecadet

--- a/src/bluecadet/views/LineView.cpp
+++ b/src/bluecadet/views/LineView.cpp
@@ -26,7 +26,7 @@ void LineView::draw() {
 	//! This was introduced because of a bug that was causing gl::ScopedColor to override the parent views tint/alpha
 	ColorA correctedColor = mLineColor.value() * getDrawColor();
 	gl::ScopedColor color(correctedColor);
-	float screenScale = bluecadet::core::ScreenCamera::getInstance()->getScale().x;
+	float screenScale = bluecadet::core::ScreenCamera::get()->getScale().x;
 	gl::ScopedLineWidth lineWidth(mLineWidth * screenScale);
 	gl::drawLine(vec2(0, 0), getEndPoint());
 }

--- a/src/bluecadet/views/TextView.cpp
+++ b/src/bluecadet/views/TextView.cpp
@@ -36,7 +36,7 @@ void TextView::setup(const std::wstring & text, const std::string & styleKey, co
 	setMaxWidth(maxWidth);
 
 	if (text.empty()) {
-		auto style = text::StyleManager::getInstance()->getStyle(styleKey);
+		auto style = text::StyleManager::get()->getStyle(styleKey);
 		setCurrentStyle(style);
 	} else if (parseText) {
 		setText(text, styleKey, customTokenParsers);

--- a/src/bluecadet/views/TouchView.cpp
+++ b/src/bluecadet/views/TouchView.cpp
@@ -185,7 +185,7 @@ void TouchView::processTouchEnded(const touch::TouchEvent& touchEvent) {
 }
 
 void TouchView::cancelTouches() {
-	std::shared_ptr<touch::TouchManager> touchManager = touch::TouchManager::getInstance();
+	std::shared_ptr<touch::TouchManager> touchManager = touch::TouchManager::get();
 	touchManager->cancelTouch(getSharedTouchViewPtr());
 	resetTouchState();
 }


### PR DESCRIPTION
- Renames all occurrences of `getInstance()` to `get()`
- Revises `GraphView` to support showing/hiding graphs, better text rendering, flexible sizes and layouts
- Switching to `ci::gl::TextureFont` instead of `gl::drawString()` for all debug text
- Refactored `SimulatedTouchDriver` to support fewer than 1 touches per second