### PR TITLE
update template SettingsManager syntax

### DIFF
--- a/templates/Bluecadet App/src/_TBOX_PREFIX_App.cpp
+++ b/templates/Bluecadet App/src/_TBOX_PREFIX_App.cpp
@@ -27,9 +27,10 @@ void _TBOX_PREFIX_App::prepareSettings(ci::app::App::Settings *settings) {
 	// SettingsManager::setInstance(myApp::MyAppSettingsManager::getInstance());
 
 	// Initialize the settings manager with the cinder app settings and the settings json
-	SettingsManager::getInstance()->setup(
+	SettingsManager::get()->setup(
 		settings,
 		ci::app::getAssetPath("settings.json"),
+		true,
 		[](SettingsManager *manager) {
 			// Optional: Override json defaults at runtime
 			manager->mFullscreen = false;


### PR DESCRIPTION
fix issue with cinder template using outdated syntax for SettingsManager